### PR TITLE
Avoid yearly updates on LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 Roave, LLC.
+Copyright (c) Roave, LLC.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This PR removes the *year* on the LICENSE file in order to avoid yearly updates.