### PR TITLE
Use native invocations instead of explicit __invoke()

### DIFF
--- a/src/Command/AssertBackwardsCompatible.php
+++ b/src/Command/AssertBackwardsCompatible.php
@@ -167,18 +167,18 @@ USAGE
             Assert::that($fromSources)->directory();
             Assert::that($toSources)->directory();
 
-            $changes = $this->compareApi->__invoke(
-                $this->reflectorFactory->__invoke(
+            $changes = ($this->compareApi)(
+                ($this->reflectorFactory)(
                     $fromPath . '/' . $sourcesPath,
                     new AggregateSourceLocator() // no dependencies
                 ),
-                $this->reflectorFactory->__invoke(
+                ($this->reflectorFactory)(
                     $fromPath . '/' . $sourcesPath,
-                    $this->locateDependencies->__invoke((string) $fromPath)
+                    ($this->locateDependencies)((string) $fromPath)
                 ),
-                $this->reflectorFactory->__invoke(
+                ($this->reflectorFactory)(
                     $toPath . '/' . $sourcesPath,
-                    $this->locateDependencies->__invoke((string) $toPath)
+                    ($this->locateDependencies)((string) $toPath)
                 )
             );
 

--- a/src/CompareClasses.php
+++ b/src/CompareClasses.php
@@ -72,13 +72,13 @@ final class CompareClasses implements CompareApi
         }
 
         if ($oldSymbol->isInterface()) {
-            return $changelog->mergeWith($this->interfaceBasedComparisons->__invoke($oldSymbol, $newClass));
+            return $changelog->mergeWith(($this->interfaceBasedComparisons)($oldSymbol, $newClass));
         }
 
         if ($oldSymbol->isTrait()) {
-            return $changelog->mergeWith($this->traitBasedComparisons->__invoke($oldSymbol, $newClass));
+            return $changelog->mergeWith(($this->traitBasedComparisons)($oldSymbol, $newClass));
         }
 
-        return $changelog->mergeWith($this->classBasedComparisons->__invoke($oldSymbol, $newClass));
+        return $changelog->mergeWith(($this->classBasedComparisons)($oldSymbol, $newClass));
     }
 }

--- a/src/DetectChanges/BCBreak/ClassBased/ConstantChanged.php
+++ b/src/DetectChanges/BCBreak/ClassBased/ConstantChanged.php
@@ -30,7 +30,7 @@ final class ConstantChanged implements ClassBased
         return array_reduce(
             array_keys($commonConstants),
             function (Changes $accumulator, string $constantName) use ($constantsFrom, $constantsTo) : Changes {
-                return $accumulator->mergeWith($this->checkConstant->__invoke(
+                return $accumulator->mergeWith(($this->checkConstant)(
                     $constantsFrom[$constantName],
                     $constantsTo[$constantName]
                 ));

--- a/src/DetectChanges/BCBreak/ClassBased/FinalClassChanged.php
+++ b/src/DetectChanges/BCBreak/ClassBased/FinalClassChanged.php
@@ -23,6 +23,6 @@ final class FinalClassChanged implements ClassBased
             return Changes::empty();
         }
 
-        return $this->checkClass->__invoke($fromClass, $toClass);
+        return ($this->checkClass)($fromClass, $toClass);
     }
 }

--- a/src/DetectChanges/BCBreak/ClassBased/MethodChanged.php
+++ b/src/DetectChanges/BCBreak/ClassBased/MethodChanged.php
@@ -34,7 +34,7 @@ final class MethodChanged implements ClassBased
         return array_reduce(
             array_keys($commonMethods),
             function (Changes $accumulator, string $methodName) use ($methodsFrom, $methodsTo) : Changes {
-                return $accumulator->mergeWith($this->checkMethod->__invoke(
+                return $accumulator->mergeWith(($this->checkMethod)(
                     $methodsFrom[$methodName],
                     $methodsTo[$methodName]
                 ));

--- a/src/DetectChanges/BCBreak/ClassBased/MethodRemoved.php
+++ b/src/DetectChanges/BCBreak/ClassBased/MethodRemoved.php
@@ -37,7 +37,7 @@ final class MethodRemoved implements ClassBased
 
         return Changes::fromList(...array_values(array_map(function (ReflectionMethod $method) : Change {
             return Change::removed(
-                sprintf('Method %s was removed', $this->formatFunction->__invoke($method)),
+                sprintf('Method %s was removed', ($this->formatFunction)($method)),
                 true
             );
         }, $removedMethods)));

--- a/src/DetectChanges/BCBreak/ClassBased/MultipleChecksOnAClass.php
+++ b/src/DetectChanges/BCBreak/ClassBased/MultipleChecksOnAClass.php
@@ -23,7 +23,7 @@ final class MultipleChecksOnAClass implements ClassBased
         return array_reduce(
             $this->checks,
             function (Changes $changes, ClassBased $check) use ($fromClass, $toClass) : Changes {
-                return $changes->mergeWith($check->__invoke($fromClass, $toClass));
+                return $changes->mergeWith($check($fromClass, $toClass));
             },
             Changes::empty()
         );

--- a/src/DetectChanges/BCBreak/ClassBased/OpenClassChanged.php
+++ b/src/DetectChanges/BCBreak/ClassBased/OpenClassChanged.php
@@ -23,6 +23,6 @@ final class OpenClassChanged implements ClassBased
             return Changes::empty();
         }
 
-        return $this->checkClass->__invoke($fromClass, $toClass);
+        return ($this->checkClass)($fromClass, $toClass);
     }
 }

--- a/src/DetectChanges/BCBreak/ClassBased/PropertyChanged.php
+++ b/src/DetectChanges/BCBreak/ClassBased/PropertyChanged.php
@@ -30,7 +30,7 @@ final class PropertyChanged implements ClassBased
         return array_reduce(
             array_keys($commonProperties),
             function (Changes $accumulator, string $propertyName) use ($propertiesFrom, $propertiesTo) : Changes {
-                return $accumulator->mergeWith($this->checkProperty->__invoke(
+                return $accumulator->mergeWith(($this->checkProperty)(
                     $propertiesFrom[$propertyName],
                     $propertiesTo[$propertyName]
                 ));

--- a/src/DetectChanges/BCBreak/ClassBased/PropertyRemoved.php
+++ b/src/DetectChanges/BCBreak/ClassBased/PropertyRemoved.php
@@ -36,7 +36,7 @@ final class PropertyRemoved implements ClassBased
 
         return Changes::fromList(...array_values(array_map(function (string $property) use ($fromProperties) : Change {
             return Change::removed(
-                sprintf('Property %s was removed', $this->formatProperty->__invoke($fromProperties[$property])),
+                sprintf('Property %s was removed', ($this->formatProperty)($fromProperties[$property])),
                 true
             );
         }, $removedProperties)));

--- a/src/DetectChanges/BCBreak/ClassConstantBased/MultipleChecksOnAClassConstant.php
+++ b/src/DetectChanges/BCBreak/ClassConstantBased/MultipleChecksOnAClassConstant.php
@@ -23,7 +23,7 @@ final class MultipleChecksOnAClassConstant implements ClassConstantBased
         return array_reduce(
             $this->checks,
             function (Changes $changes, ClassConstantBased $check) use ($fromConstant, $toConstant) : Changes {
-                return $changes->mergeWith($check->__invoke($fromConstant, $toConstant));
+                return $changes->mergeWith($check($fromConstant, $toConstant));
             },
             Changes::empty()
         );

--- a/src/DetectChanges/BCBreak/ClassConstantBased/OnlyProtectedClassConstantChanged.php
+++ b/src/DetectChanges/BCBreak/ClassConstantBased/OnlyProtectedClassConstantChanged.php
@@ -23,6 +23,6 @@ final class OnlyProtectedClassConstantChanged implements ClassConstantBased
             return Changes::empty();
         }
 
-        return $this->constantCheck->__invoke($fromConstant, $toConstant);
+        return ($this->constantCheck)($fromConstant, $toConstant);
     }
 }

--- a/src/DetectChanges/BCBreak/ClassConstantBased/OnlyPublicClassConstantChanged.php
+++ b/src/DetectChanges/BCBreak/ClassConstantBased/OnlyPublicClassConstantChanged.php
@@ -23,6 +23,6 @@ final class OnlyPublicClassConstantChanged implements ClassConstantBased
             return Changes::empty();
         }
 
-        return $this->constantCheck->__invoke($fromConstant, $toConstant);
+        return ($this->constantCheck)($fromConstant, $toConstant);
     }
 }

--- a/src/DetectChanges/BCBreak/FunctionBased/MultipleChecksOnAFunction.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/MultipleChecksOnAFunction.php
@@ -23,7 +23,7 @@ final class MultipleChecksOnAFunction implements FunctionBased
         return array_reduce(
             $this->checks,
             function (Changes $changes, FunctionBased $check) use ($fromFunction, $toClass) : Changes {
-                return $changes->mergeWith($check->__invoke($fromFunction, $toClass));
+                return $changes->mergeWith($check($fromFunction, $toClass));
             },
             Changes::empty()
         );

--- a/src/DetectChanges/BCBreak/FunctionBased/ParameterByReferenceChanged.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/ParameterByReferenceChanged.php
@@ -57,7 +57,7 @@ final class ParameterByReferenceChanged implements FunctionBased
             sprintf(
                 'The parameter $%s of %s changed from %s to %s',
                 $fromParameter->getName(),
-                $this->formatFunction->__invoke($fromParameter->getDeclaringFunction()),
+                ($this->formatFunction)($fromParameter->getDeclaringFunction()),
                 $this->referenceToString($fromByReference),
                 $this->referenceToString($toByReference)
             ),

--- a/src/DetectChanges/BCBreak/FunctionBased/ParameterDefaultValueChanged.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/ParameterDefaultValueChanged.php
@@ -53,7 +53,7 @@ final class ParameterDefaultValueChanged implements FunctionBased
                 sprintf(
                     'Default parameter value for for parameter $%s of %s changed from %s to %s',
                     $parameter->getName(),
-                    $this->formatFunction->__invoke($fromFunction),
+                    ($this->formatFunction)($fromFunction),
                     var_export($defaultValueFrom, true),
                     var_export($defaultValueTo, true)
                 ),

--- a/src/DetectChanges/BCBreak/FunctionBased/ParameterTypeChanged.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/ParameterTypeChanged.php
@@ -59,7 +59,7 @@ final class ParameterTypeChanged implements FunctionBased
             sprintf(
                 'The parameter $%s of %s changed from %s to %s',
                 $fromParameter->getName(),
-                $this->formatFunction->__invoke($fromParameter->getDeclaringFunction()),
+                ($this->formatFunction)($fromParameter->getDeclaringFunction()),
                 $fromType,
                 $toType
             ),

--- a/src/DetectChanges/BCBreak/FunctionBased/ParameterTypeContravarianceChanged.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/ParameterTypeContravarianceChanged.php
@@ -54,7 +54,7 @@ final class ParameterTypeContravarianceChanged implements FunctionBased
         $fromType = $fromParameter->getType();
         $toType   = $toParameter->getType();
 
-        if ($this->typeIsContravariant->__invoke($fromType, $toType)) {
+        if (($this->typeIsContravariant)($fromType, $toType)) {
             return Changes::empty();
         }
 
@@ -62,7 +62,7 @@ final class ParameterTypeContravarianceChanged implements FunctionBased
             sprintf(
                 'The parameter $%s of %s changed from %s to a non-contravariant %s',
                 $fromParameter->getName(),
-                $this->formatFunction->__invoke($fromParameter->getDeclaringFunction()),
+                ($this->formatFunction)($fromParameter->getDeclaringFunction()),
                 $this->typeToString($fromType),
                 $this->typeToString($toType)
             ),

--- a/src/DetectChanges/BCBreak/FunctionBased/RequiredParameterAmountIncreased.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/RequiredParameterAmountIncreased.php
@@ -36,7 +36,7 @@ final class RequiredParameterAmountIncreased implements FunctionBased
         return Changes::fromList(Change::changed(
             sprintf(
                 'The number of required arguments for %s increased from %d to %d',
-                $this->formatFunction->__invoke($fromFunction),
+                ($this->formatFunction)($fromFunction),
                 $fromRequiredParameters,
                 $toRequiredParameters
             ),

--- a/src/DetectChanges/BCBreak/FunctionBased/ReturnTypeByReferenceChanged.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/ReturnTypeByReferenceChanged.php
@@ -36,7 +36,7 @@ final class ReturnTypeByReferenceChanged implements FunctionBased
         return Changes::fromList(Change::changed(
             sprintf(
                 'The return value of %s changed from %s to %s',
-                $this->formatFunction->__invoke($fromFunction),
+                ($this->formatFunction)($fromFunction),
                 $this->referenceToString($fromReturnsReference),
                 $this->referenceToString($toReturnsReference)
             ),

--- a/src/DetectChanges/BCBreak/FunctionBased/ReturnTypeChanged.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/ReturnTypeChanged.php
@@ -38,7 +38,7 @@ final class ReturnTypeChanged implements FunctionBased
         return Changes::fromList(Change::changed(
             sprintf(
                 'The return type of %s changed from %s to %s',
-                $this->formatFunction->__invoke($fromFunction),
+                ($this->formatFunction)($fromFunction),
                 $fromReturnType,
                 $toReturnType
             ),

--- a/src/DetectChanges/BCBreak/FunctionBased/ReturnTypeCovarianceChanged.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/ReturnTypeCovarianceChanged.php
@@ -36,14 +36,14 @@ final class ReturnTypeCovarianceChanged implements FunctionBased
         $fromReturnType = $fromFunction->getReturnType();
         $toReturnType   = $toFunction->getReturnType();
 
-        if ($this->typeIsCovariant->__invoke($fromReturnType, $toReturnType)) {
+        if (($this->typeIsCovariant)($fromReturnType, $toReturnType)) {
             return Changes::empty();
         }
 
         return Changes::fromList(Change::changed(
             sprintf(
                 'The return type of %s changed from %s to the non-covariant %s',
-                $this->formatFunction->__invoke($fromFunction),
+                ($this->formatFunction)($fromFunction),
                 $this->typeToString($fromReturnType),
                 $this->typeToString($toReturnType)
             ),

--- a/src/DetectChanges/BCBreak/InterfaceBased/MultipleChecksOnAnInterface.php
+++ b/src/DetectChanges/BCBreak/InterfaceBased/MultipleChecksOnAnInterface.php
@@ -23,7 +23,7 @@ final class MultipleChecksOnAnInterface implements InterfaceBased
         return array_reduce(
             $this->checks,
             function (Changes $changes, InterfaceBased $check) use ($fromClass, $toClass) : Changes {
-                return $changes->mergeWith($check->__invoke($fromClass, $toClass));
+                return $changes->mergeWith($check($fromClass, $toClass));
             },
             Changes::empty()
         );

--- a/src/DetectChanges/BCBreak/InterfaceBased/UseClassBasedChecksOnAnInterface.php
+++ b/src/DetectChanges/BCBreak/InterfaceBased/UseClassBasedChecksOnAnInterface.php
@@ -20,6 +20,6 @@ final class UseClassBasedChecksOnAnInterface implements InterfaceBased
 
     public function __invoke(ReflectionClass $fromClass, ReflectionClass $toClass) : Changes
     {
-        return $this->check->__invoke($fromClass, $toClass);
+        return ($this->check)($fromClass, $toClass);
     }
 }

--- a/src/DetectChanges/BCBreak/MethodBased/AccessibleMethodChange.php
+++ b/src/DetectChanges/BCBreak/MethodBased/AccessibleMethodChange.php
@@ -26,6 +26,6 @@ final class AccessibleMethodChange implements MethodBased
             return Changes::empty();
         }
 
-        return $this->check->__invoke($fromMethod, $toMethod);
+        return ($this->check)($fromMethod, $toMethod);
     }
 }

--- a/src/DetectChanges/BCBreak/MethodBased/MethodFunctionDefinitionChanged.php
+++ b/src/DetectChanges/BCBreak/MethodBased/MethodFunctionDefinitionChanged.php
@@ -23,6 +23,6 @@ final class MethodFunctionDefinitionChanged implements MethodBased
 
     public function __invoke(ReflectionMethod $fromMethod, ReflectionMethod $toMethod) : Changes
     {
-        return $this->functionCheck->__invoke($fromMethod, $toMethod);
+        return ($this->functionCheck)($fromMethod, $toMethod);
     }
 }

--- a/src/DetectChanges/BCBreak/MethodBased/MultipleChecksOnAMethod.php
+++ b/src/DetectChanges/BCBreak/MethodBased/MultipleChecksOnAMethod.php
@@ -23,7 +23,7 @@ final class MultipleChecksOnAMethod implements MethodBased
         return array_reduce(
             $this->checks,
             function (Changes $changes, MethodBased $check) use ($fromMethod, $toMethod) : Changes {
-                return $changes->mergeWith($check->__invoke($fromMethod, $toMethod));
+                return $changes->mergeWith($check($fromMethod, $toMethod));
             },
             Changes::empty()
         );

--- a/src/DetectChanges/BCBreak/MethodBased/OnlyProtectedMethodChanged.php
+++ b/src/DetectChanges/BCBreak/MethodBased/OnlyProtectedMethodChanged.php
@@ -26,6 +26,6 @@ final class OnlyProtectedMethodChanged implements MethodBased
             return Changes::empty();
         }
 
-        return $this->check->__invoke($fromMethod, $toMethod);
+        return ($this->check)($fromMethod, $toMethod);
     }
 }

--- a/src/DetectChanges/BCBreak/MethodBased/OnlyPublicMethodChanged.php
+++ b/src/DetectChanges/BCBreak/MethodBased/OnlyPublicMethodChanged.php
@@ -26,6 +26,6 @@ final class OnlyPublicMethodChanged implements MethodBased
             return Changes::empty();
         }
 
-        return $this->check->__invoke($fromMethod, $toMethod);
+        return ($this->check)($fromMethod, $toMethod);
     }
 }

--- a/src/DetectChanges/BCBreak/PropertyBased/AccessiblePropertyChanged.php
+++ b/src/DetectChanges/BCBreak/PropertyBased/AccessiblePropertyChanged.php
@@ -23,6 +23,6 @@ final class AccessiblePropertyChanged implements PropertyBased
             return Changes::empty();
         }
 
-        return $this->propertyBased->__invoke($fromProperty, $toProperty);
+        return ($this->propertyBased)($fromProperty, $toProperty);
     }
 }

--- a/src/DetectChanges/BCBreak/PropertyBased/MultipleChecksOnAProperty.php
+++ b/src/DetectChanges/BCBreak/PropertyBased/MultipleChecksOnAProperty.php
@@ -23,7 +23,7 @@ final class MultipleChecksOnAProperty implements PropertyBased
         return array_reduce(
             $this->checks,
             function (Changes $changes, PropertyBased $check) use ($fromProperty, $toProperty) : Changes {
-                return $changes->mergeWith($check->__invoke($fromProperty, $toProperty));
+                return $changes->mergeWith($check($fromProperty, $toProperty));
             },
             Changes::empty()
         );

--- a/src/DetectChanges/BCBreak/PropertyBased/OnlyProtectedPropertyChanged.php
+++ b/src/DetectChanges/BCBreak/PropertyBased/OnlyProtectedPropertyChanged.php
@@ -23,6 +23,6 @@ final class OnlyProtectedPropertyChanged implements PropertyBased
             return Changes::empty();
         }
 
-        return $this->propertyBased->__invoke($fromProperty, $toProperty);
+        return ($this->propertyBased)($fromProperty, $toProperty);
     }
 }

--- a/src/DetectChanges/BCBreak/PropertyBased/OnlyPublicPropertyChanged.php
+++ b/src/DetectChanges/BCBreak/PropertyBased/OnlyPublicPropertyChanged.php
@@ -23,6 +23,6 @@ final class OnlyPublicPropertyChanged implements PropertyBased
             return Changes::empty();
         }
 
-        return $this->propertyBased->__invoke($fromProperty, $toProperty);
+        return ($this->propertyBased)($fromProperty, $toProperty);
     }
 }

--- a/src/DetectChanges/BCBreak/PropertyBased/PropertyDefaultValueChanged.php
+++ b/src/DetectChanges/BCBreak/PropertyBased/PropertyDefaultValueChanged.php
@@ -33,7 +33,7 @@ final class PropertyDefaultValueChanged implements PropertyBased
         return Changes::fromList(Change::changed(
             sprintf(
                 'Property %s changed default value from %s to %s',
-                $this->formatProperty->__invoke($fromProperty),
+                ($this->formatProperty)($fromProperty),
                 var_export($fromPropertyDefaultValue, true),
                 var_export($toPropertyDefaultValue, true)
             ),

--- a/src/DetectChanges/BCBreak/PropertyBased/PropertyDocumentedTypeChanged.php
+++ b/src/DetectChanges/BCBreak/PropertyBased/PropertyDocumentedTypeChanged.php
@@ -47,7 +47,7 @@ final class PropertyDocumentedTypeChanged implements PropertyBased
         return Changes::fromList(Change::changed(
             sprintf(
                 'Type documentation for property %s changed from %s to %s',
-                $this->formatProperty->__invoke($fromProperty),
+                ($this->formatProperty)($fromProperty),
                 implode('|', $fromTypes) ?: 'having no type',
                 implode('|', $toTypes) ?: 'having no type'
             ),

--- a/src/DetectChanges/BCBreak/PropertyBased/PropertyVisibilityReduced.php
+++ b/src/DetectChanges/BCBreak/PropertyBased/PropertyVisibilityReduced.php
@@ -39,7 +39,7 @@ final class PropertyVisibilityReduced implements PropertyBased
         return Changes::fromList(Change::changed(
             sprintf(
                 'Property %s visibility reduced from %s to %s',
-                $this->formatProperty->__invoke($fromProperty),
+                ($this->formatProperty)($fromProperty),
                 $visibilityFrom,
                 $visibilityTo
             ),

--- a/src/DetectChanges/BCBreak/TraitBased/MultipleChecksOnATrait.php
+++ b/src/DetectChanges/BCBreak/TraitBased/MultipleChecksOnATrait.php
@@ -23,7 +23,7 @@ final class MultipleChecksOnATrait implements TraitBased
         return array_reduce(
             $this->checks,
             function (Changes $changes, TraitBased $check) use ($fromTrait, $toTrait) : Changes {
-                return $changes->mergeWith($check->__invoke($fromTrait, $toTrait));
+                return $changes->mergeWith($check($fromTrait, $toTrait));
             },
             Changes::empty()
         );

--- a/src/DetectChanges/BCBreak/TraitBased/UseClassBasedChecksOnATrait.php
+++ b/src/DetectChanges/BCBreak/TraitBased/UseClassBasedChecksOnATrait.php
@@ -20,6 +20,6 @@ final class UseClassBasedChecksOnATrait implements TraitBased
 
     public function __invoke(ReflectionClass $fromTrait, ReflectionClass $toTrait) : Changes
     {
-        return $this->check->__invoke($fromTrait, $toTrait);
+        return ($this->check)($fromTrait, $toTrait);
     }
 }

--- a/test/unit/CompareClassesTest.php
+++ b/test/unit/CompareClassesTest.php
@@ -60,9 +60,9 @@ final class CompareClassesTest extends TestCase
 
         self::assertEqualsIgnoringOrder(
             Changes::fromList(Change::changed('class change', true)),
-            $this->compareClasses->__invoke(
-                self::$stringReflectorFactory->__invoke('<?php class A {}'),
-                self::$stringReflectorFactory->__invoke(
+            ($this->compareClasses)(
+                (self::$stringReflectorFactory)('<?php class A {}'),
+                (self::$stringReflectorFactory)(
                     <<<'PHP'
 <?php
 
@@ -73,7 +73,7 @@ class A {
 }
 PHP
                 ),
-                self::$stringReflectorFactory->__invoke(
+                (self::$stringReflectorFactory)(
                     <<<'PHP'
 <?php
 
@@ -96,9 +96,9 @@ PHP
 
         self::assertEqualsIgnoringOrder(
             Changes::fromList(Change::changed('class change', true)),
-            $this->compareClasses->__invoke(
-                self::$stringReflectorFactory->__invoke('<?php class A {}'),
-                self::$stringReflectorFactory->__invoke(
+            ($this->compareClasses)(
+                (self::$stringReflectorFactory)('<?php class A {}'),
+                (self::$stringReflectorFactory)(
                     <<<'PHP'
 <?php
 
@@ -109,7 +109,7 @@ class A {
 }
 PHP
                 ),
-                self::$stringReflectorFactory->__invoke(
+                (self::$stringReflectorFactory)(
                     <<<'PHP'
 <?php
 
@@ -128,10 +128,10 @@ PHP
 
         self::assertEqualsIgnoringOrder(
             Changes::fromList(Change::changed('interface change', true)),
-            $this->compareClasses->__invoke(
-                self::$stringReflectorFactory->__invoke('<?php interface A {}'),
-                self::$stringReflectorFactory->__invoke('<?php interface A {}'),
-                self::$stringReflectorFactory->__invoke('<?php interface A {}')
+            ($this->compareClasses)(
+                (self::$stringReflectorFactory)('<?php interface A {}'),
+                (self::$stringReflectorFactory)('<?php interface A {}'),
+                (self::$stringReflectorFactory)('<?php interface A {}')
             )
         );
     }
@@ -144,10 +144,10 @@ PHP
 
         self::assertEqualsIgnoringOrder(
             Changes::fromList(Change::changed('trait change', true)),
-            $this->compareClasses->__invoke(
-                self::$stringReflectorFactory->__invoke('<?php trait A {}'),
-                self::$stringReflectorFactory->__invoke('<?php trait A {}'),
-                self::$stringReflectorFactory->__invoke('<?php trait A {}')
+            ($this->compareClasses)(
+                (self::$stringReflectorFactory)('<?php trait A {}'),
+                (self::$stringReflectorFactory)('<?php trait A {}'),
+                (self::$stringReflectorFactory)('<?php trait A {}')
             )
         );
     }
@@ -167,10 +167,10 @@ PHP
 
         self::assertEqualsIgnoringOrder(
             Changes::empty(),
-            $this->compareClasses->__invoke(
-                self::$stringReflectorFactory->__invoke('<?php '),
-                self::$stringReflectorFactory->__invoke('<?php class A { private function foo() {} }'),
-                self::$stringReflectorFactory->__invoke('<?php ')
+            ($this->compareClasses)(
+                (self::$stringReflectorFactory)('<?php '),
+                (self::$stringReflectorFactory)('<?php class A { private function foo() {} }'),
+                (self::$stringReflectorFactory)('<?php ')
             )
         );
     }
@@ -183,10 +183,10 @@ PHP
 
         self::assertEqualsIgnoringOrder(
             Changes::fromList(Change::removed('Class A has been deleted', true)),
-            $this->compareClasses->__invoke(
-                self::$stringReflectorFactory->__invoke('<?php class A { private function foo() {} }'),
-                self::$stringReflectorFactory->__invoke('<?php class A { private function foo() {} }'),
-                self::$stringReflectorFactory->__invoke('<?php ')
+            ($this->compareClasses)(
+                (self::$stringReflectorFactory)('<?php class A { private function foo() {} }'),
+                (self::$stringReflectorFactory)('<?php class A { private function foo() {} }'),
+                (self::$stringReflectorFactory)('<?php ')
             )
         );
     }

--- a/test/unit/DetectChanges/BCBreak/ClassBased/FinalClassChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/FinalClassChangedTest.php
@@ -57,7 +57,7 @@ final class FinalClassChangedTest extends TestCase
             ->with($this->fromClass, $this->toClass)
             ->willReturn($changes);
 
-        self::assertEquals($changes, $this->finalClassChanged->__invoke($this->fromClass, $this->toClass));
+        self::assertEquals($changes, ($this->finalClassChanged)($this->fromClass, $this->toClass));
     }
 
     public function testWillNotCheckOpenClass() : void
@@ -73,6 +73,6 @@ final class FinalClassChangedTest extends TestCase
             ->expects(self::never())
             ->method('__invoke');
 
-        self::assertEquals(Changes::empty(), $this->finalClassChanged->__invoke($this->fromClass, $this->toClass));
+        self::assertEquals(Changes::empty(), ($this->finalClassChanged)($this->fromClass, $this->toClass));
     }
 }

--- a/test/unit/DetectChanges/BCBreak/ClassBased/MultipleChecksOnAClassTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/MultipleChecksOnAClassTest.php
@@ -57,7 +57,7 @@ final class MultipleChecksOnAClassTest extends TestCase
                 Change::added('2', true),
                 Change::added('3', true)
             ),
-            $multiCheck->__invoke($from, $to)
+            $multiCheck($from, $to)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/ClassBased/OpenClassChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/OpenClassChangedTest.php
@@ -58,7 +58,7 @@ final class OpenClassChangedTest extends TestCase
             ->with($this->fromClass, $this->toClass)
             ->willReturn($changes);
 
-        self::assertEquals($changes, $this->openClassChanged->__invoke($this->fromClass, $this->toClass));
+        self::assertEquals($changes, ($this->openClassChanged)($this->fromClass, $this->toClass));
     }
 
     public function testWillNotCheckOpenClass() : void
@@ -74,6 +74,6 @@ final class OpenClassChangedTest extends TestCase
             ->expects(self::never())
             ->method('__invoke');
 
-        self::assertEquals(Changes::empty(), $this->openClassChanged->__invoke($this->fromClass, $this->toClass));
+        self::assertEquals(Changes::empty(), ($this->openClassChanged)($this->fromClass, $this->toClass));
     }
 }

--- a/test/unit/DetectChanges/BCBreak/ClassConstantBased/MultipleChecksOnAClassConstantTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassConstantBased/MultipleChecksOnAClassConstantTest.php
@@ -57,7 +57,7 @@ final class MultipleChecksOnAClassConstantTest extends TestCase
                 Change::added('2', true),
                 Change::added('3', true)
             ),
-            $multiCheck->__invoke($from, $to)
+            $multiCheck($from, $to)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/ClassConstantBased/OnlyProtectedClassConstantChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassConstantBased/OnlyProtectedClassConstantChangedTest.php
@@ -55,7 +55,7 @@ final class OnlyProtectedClassConstantChangedTest extends TestCase
 
         self::assertEquals(
             Changes::empty(),
-            $this->changed->__invoke($this->fromConstant, $this->toConstant)
+            ($this->changed)($this->fromConstant, $this->toConstant)
         );
     }
 
@@ -78,7 +78,7 @@ final class OnlyProtectedClassConstantChangedTest extends TestCase
 
         self::assertEquals(
             $changes,
-            $this->changed->__invoke($this->fromConstant, $this->toConstant)
+            ($this->changed)($this->fromConstant, $this->toConstant)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/ClassConstantBased/OnlyPublicClassConstantChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassConstantBased/OnlyPublicClassConstantChangedTest.php
@@ -55,7 +55,7 @@ final class OnlyPublicClassConstantChangedTest extends TestCase
 
         self::assertEquals(
             Changes::empty(),
-            $this->changed->__invoke($this->fromConstant, $this->toConstant)
+            ($this->changed)($this->fromConstant, $this->toConstant)
         );
     }
 
@@ -78,7 +78,7 @@ final class OnlyPublicClassConstantChangedTest extends TestCase
 
         self::assertEquals(
             $changes,
-            $this->changed->__invoke($this->fromConstant, $this->toConstant)
+            ($this->changed)($this->fromConstant, $this->toConstant)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/MultipleChecksOnAFunctionTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/MultipleChecksOnAFunctionTest.php
@@ -57,7 +57,7 @@ final class MultipleChecksOnAFunctionTest extends TestCase
                 Change::added('2', true),
                 Change::added('3', true)
             ),
-            $multiCheck->__invoke($from, $to)
+            $multiCheck($from, $to)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/InterfaceBased/MultipleChecksOnAnInterfaceTest.php
+++ b/test/unit/DetectChanges/BCBreak/InterfaceBased/MultipleChecksOnAnInterfaceTest.php
@@ -57,7 +57,7 @@ final class MultipleChecksOnAnInterfaceTest extends TestCase
                 Change::added('2', true),
                 Change::added('3', true)
             ),
-            $multiCheck->__invoke($from, $to)
+            $multiCheck($from, $to)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/MethodBased/AccessibleMethodChangeTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/AccessibleMethodChangeTest.php
@@ -49,7 +49,7 @@ final class AccessibleMethodChangeTest extends TestCase
             ->expects(self::never())
             ->method('__invoke');
 
-        self::assertEquals(Changes::empty(), $this->methodCheck->__invoke($from, $to));
+        self::assertEquals(Changes::empty(), ($this->methodCheck)($from, $to));
     }
 
     public function testWillCheckVisibleMethods() : void
@@ -73,6 +73,6 @@ final class AccessibleMethodChangeTest extends TestCase
             ->with($from, $to)
             ->willReturn($result);
 
-        self::assertEquals($result, $this->methodCheck->__invoke($from, $to));
+        self::assertEquals($result, ($this->methodCheck)($from, $to));
     }
 }

--- a/test/unit/DetectChanges/BCBreak/MethodBased/MethodFunctionDefinitionChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/MethodFunctionDefinitionChangedTest.php
@@ -49,6 +49,6 @@ final class MethodFunctionDefinitionChangedTest extends TestCase
             ->with($from, $to)
             ->willReturn($result);
 
-        self::assertEquals($result, $this->methodCheck->__invoke($from, $to));
+        self::assertEquals($result, ($this->methodCheck)($from, $to));
     }
 }

--- a/test/unit/DetectChanges/BCBreak/MethodBased/MultipleChecksOnAMethodTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/MultipleChecksOnAMethodTest.php
@@ -57,7 +57,7 @@ final class MultipleChecksOnAMethodTest extends TestCase
                 Change::added('2', true),
                 Change::added('3', true)
             ),
-            $multiCheck->__invoke($from, $to)
+            $multiCheck($from, $to)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/MethodBased/OnlyProtectedMethodChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/OnlyProtectedMethodChangedTest.php
@@ -49,7 +49,7 @@ final class OnlyProtectedMethodChangedTest extends TestCase
             ->expects(self::never())
             ->method('__invoke');
 
-        self::assertEquals(Changes::empty(), $this->methodCheck->__invoke($from, $to));
+        self::assertEquals(Changes::empty(), ($this->methodCheck)($from, $to));
     }
 
     public function testWillCheckProtectedMethods() : void
@@ -73,6 +73,6 @@ final class OnlyProtectedMethodChangedTest extends TestCase
             ->with($from, $to)
             ->willReturn($result);
 
-        self::assertEquals($result, $this->methodCheck->__invoke($from, $to));
+        self::assertEquals($result, ($this->methodCheck)($from, $to));
     }
 }

--- a/test/unit/DetectChanges/BCBreak/MethodBased/OnlyPublicMethodChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/OnlyPublicMethodChangedTest.php
@@ -49,7 +49,7 @@ final class OnlyPublicMethodChangedTest extends TestCase
             ->expects(self::never())
             ->method('__invoke');
 
-        self::assertEquals(Changes::empty(), $this->methodCheck->__invoke($from, $to));
+        self::assertEquals(Changes::empty(), ($this->methodCheck)($from, $to));
     }
 
     public function testWillCheckPublicMethods() : void
@@ -73,6 +73,6 @@ final class OnlyPublicMethodChangedTest extends TestCase
             ->with($from, $to)
             ->willReturn($result);
 
-        self::assertEquals($result, $this->methodCheck->__invoke($from, $to));
+        self::assertEquals($result, ($this->methodCheck)($from, $to));
     }
 }

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/AccessiblePropertyChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/AccessiblePropertyChangedTest.php
@@ -55,7 +55,7 @@ final class AccessiblePropertyChangedTest extends TestCase
 
         self::assertEquals(
             Changes::empty(),
-            $this->accessiblePropertyChanged->__invoke($this->fromProperty, $this->toProperty)
+            ($this->accessiblePropertyChanged)($this->fromProperty, $this->toProperty)
         );
     }
 
@@ -78,7 +78,7 @@ final class AccessiblePropertyChangedTest extends TestCase
 
         self::assertEquals(
             $changes,
-            $this->accessiblePropertyChanged->__invoke($this->fromProperty, $this->toProperty)
+            ($this->accessiblePropertyChanged)($this->fromProperty, $this->toProperty)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/MultipleChecksOnAPropertyTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/MultipleChecksOnAPropertyTest.php
@@ -57,7 +57,7 @@ final class MultipleChecksOnAPropertyTest extends TestCase
                 Change::added('2', true),
                 Change::added('3', true)
             ),
-            $multiCheck->__invoke($from, $to)
+            $multiCheck($from, $to)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/OnlyProtectedPropertyChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/OnlyProtectedPropertyChangedTest.php
@@ -55,7 +55,7 @@ final class OnlyProtectedPropertyChangedTest extends TestCase
 
         self::assertEquals(
             Changes::empty(),
-            $this->changed->__invoke($this->fromProperty, $this->toProperty)
+            ($this->changed)($this->fromProperty, $this->toProperty)
         );
     }
 
@@ -78,7 +78,7 @@ final class OnlyProtectedPropertyChangedTest extends TestCase
 
         self::assertEquals(
             $changes,
-            $this->changed->__invoke($this->fromProperty, $this->toProperty)
+            ($this->changed)($this->fromProperty, $this->toProperty)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/OnlyPublicPropertyChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/OnlyPublicPropertyChangedTest.php
@@ -55,7 +55,7 @@ final class OnlyPublicPropertyChangedTest extends TestCase
 
         self::assertEquals(
             Changes::empty(),
-            $this->changed->__invoke($this->fromProperty, $this->toProperty)
+            ($this->changed)($this->fromProperty, $this->toProperty)
         );
     }
 
@@ -78,7 +78,7 @@ final class OnlyPublicPropertyChangedTest extends TestCase
 
         self::assertEquals(
             $changes,
-            $this->changed->__invoke($this->fromProperty, $this->toProperty)
+            ($this->changed)($this->fromProperty, $this->toProperty)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/TraitBased/MultipleChecksOnATraitTest.php
+++ b/test/unit/DetectChanges/BCBreak/TraitBased/MultipleChecksOnATraitTest.php
@@ -57,7 +57,7 @@ final class MultipleChecksOnATraitTest extends TestCase
                 Change::added('2', true),
                 Change::added('3', true)
             ),
-            $multiCheck->__invoke($from, $to)
+            $multiCheck($from, $to)
         );
     }
 }

--- a/test/unit/DetectChanges/Variance/TypeIsContravariantTest.php
+++ b/test/unit/DetectChanges/Variance/TypeIsContravariantTest.php
@@ -263,8 +263,8 @@ PHP
 
         $isContravariant = new TypeIsContravariant();
 
-        self::assertFalse($isContravariant->__invoke($nullable, $notNullable));
-        self::assertTrue($isContravariant->__invoke($notNullable, $nullable));
+        self::assertFalse($isContravariant($nullable, $notNullable));
+        self::assertTrue($isContravariant($notNullable, $nullable));
     }
 
     /** @return string[][] */

--- a/test/unit/DetectChanges/Variance/TypeIsCovariantTest.php
+++ b/test/unit/DetectChanges/Variance/TypeIsCovariantTest.php
@@ -274,8 +274,8 @@ PHP
 
         $isCovariant = new TypeIsCovariant();
 
-        self::assertTrue($isCovariant->__invoke($nullable, $notNullable));
-        self::assertFalse($isCovariant->__invoke($notNullable, $nullable));
+        self::assertTrue($isCovariant($nullable, $notNullable));
+        self::assertFalse($isCovariant($notNullable, $nullable));
     }
 
     /** @return string[][] */


### PR DESCRIPTION
All these `->__invoke()` things are not cool when language provides native syntax...