### PR TITLE
Filter out anonymous classes

### DIFF
--- a/bin/roave-backward-compatibility-check.php
+++ b/bin/roave-backward-compatibility-check.php
@@ -68,34 +68,110 @@ use function file_exists;
                 $astLocator
             ),
             new CompareClasses(
-                new ClassBased\MultipleChecksOnAClass(
-                    new ClassBased\ClassBecameAbstract(),
-                    new ClassBased\ClassBecameInterface(),
-                    new ClassBased\ClassBecameTrait(),
-                    new ClassBased\ClassBecameFinal(),
-                    new ClassBased\ConstantRemoved(),
-                    new ClassBased\PropertyRemoved(),
-                    new ClassBased\MethodRemoved(),
-                    new ClassBased\OpenClassChanged(
-                        new ClassBased\MultipleChecksOnAClass(
-                            new ClassBased\ConstantChanged(
-                                new ClassConstantBased\MultipleChecksOnAClassConstant(
+                new ClassBased\ExcludeAnonymousClasses(
+                    new ClassBased\MultipleChecksOnAClass(
+                        new ClassBased\ClassBecameAbstract(),
+                        new ClassBased\ClassBecameInterface(),
+                        new ClassBased\ClassBecameTrait(),
+                        new ClassBased\ClassBecameFinal(),
+                        new ClassBased\ConstantRemoved(),
+                        new ClassBased\PropertyRemoved(),
+                        new ClassBased\MethodRemoved(),
+                        new ClassBased\OpenClassChanged(
+                            new ClassBased\MultipleChecksOnAClass(
+                                new ClassBased\ConstantChanged(
+                                    new ClassConstantBased\MultipleChecksOnAClassConstant(
+                                        new ClassConstantBased\OnlyPublicClassConstantChanged(
+                                            new ClassConstantBased\MultipleChecksOnAClassConstant(
+                                                new ClassConstantBased\ClassConstantVisibilityReduced(),
+                                                new ClassConstantBased\ClassConstantValueChanged()
+                                            )
+                                        ),
+                                        new ClassConstantBased\OnlyProtectedClassConstantChanged(
+                                            new ClassConstantBased\MultipleChecksOnAClassConstant(
+                                                new ClassConstantBased\ClassConstantVisibilityReduced(),
+                                                new ClassConstantBased\ClassConstantValueChanged()
+                                            )
+                                        )
+                                    )
+                                ),
+                                new ClassBased\PropertyChanged(
+                                    new PropertyBased\MultipleChecksOnAProperty(
+                                        new PropertyBased\OnlyPublicPropertyChanged(
+                                            new PropertyBased\MultipleChecksOnAProperty(
+                                                new PropertyBased\PropertyDocumentedTypeChanged(),
+                                                new PropertyBased\PropertyDefaultValueChanged(),
+                                                new PropertyBased\PropertyVisibilityReduced(),
+                                                new PropertyBased\PropertyScopeChanged()
+                                            )
+                                        ),
+                                        new PropertyBased\OnlyProtectedPropertyChanged(
+                                            new PropertyBased\MultipleChecksOnAProperty(
+                                                new PropertyBased\PropertyDocumentedTypeChanged(),
+                                                new PropertyBased\PropertyDefaultValueChanged(),
+                                                new PropertyBased\PropertyVisibilityReduced(),
+                                                new PropertyBased\PropertyScopeChanged()
+                                            )
+                                        )
+                                    )
+                                ),
+                                new ClassBased\MethodChanged(
+                                    new MethodBased\MultipleChecksOnAMethod(
+                                        new MethodBased\OnlyPublicMethodChanged(
+                                            new MethodBased\MultipleChecksOnAMethod(
+                                                new MethodBased\MethodBecameFinal(),
+                                                new MethodBased\MethodConcretenessChanged(),
+                                                new MethodBased\MethodScopeChanged(),
+                                                new MethodBased\MethodVisibilityReduced(),
+                                                new MethodBased\MethodFunctionDefinitionChanged(
+                                                    new FunctionBased\MultipleChecksOnAFunction(
+                                                        new FunctionBased\ParameterByReferenceChanged(),
+                                                        new FunctionBased\ReturnTypeByReferenceChanged(),
+                                                        new FunctionBased\RequiredParameterAmountIncreased(),
+                                                        new FunctionBased\ParameterDefaultValueChanged(),
+                                                        new FunctionBased\ReturnTypeCovarianceChanged(new TypeIsCovariant()),
+                                                        new FunctionBased\ReturnTypeChanged(),
+                                                        new FunctionBased\ParameterTypeContravarianceChanged(new TypeIsContravariant()),
+                                                        new FunctionBased\ParameterTypeChanged()
+                                                    )
+                                                )
+                                            )
+                                        ),
+                                        new MethodBased\OnlyProtectedMethodChanged(
+                                            new MethodBased\MultipleChecksOnAMethod(
+                                                new MethodBased\MethodBecameFinal(),
+                                                new MethodBased\MethodConcretenessChanged(),
+                                                new MethodBased\MethodScopeChanged(),
+                                                new MethodBased\MethodVisibilityReduced(),
+                                                new MethodBased\MethodFunctionDefinitionChanged(
+                                                    new FunctionBased\MultipleChecksOnAFunction(
+                                                        new FunctionBased\ParameterByReferenceChanged(),
+                                                        new FunctionBased\ReturnTypeByReferenceChanged(),
+                                                        new FunctionBased\RequiredParameterAmountIncreased(),
+                                                        new FunctionBased\ParameterDefaultValueChanged(),
+                                                        new FunctionBased\ReturnTypeCovarianceChanged(new TypeIsCovariant()),
+                                                        new FunctionBased\ReturnTypeChanged(),
+                                                        new FunctionBased\ParameterTypeContravarianceChanged(new TypeIsContravariant()),
+                                                        new FunctionBased\ParameterTypeChanged()
+                                                    )
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        ),
+                        new ClassBased\FinalClassChanged(
+                            new ClassBased\MultipleChecksOnAClass(
+                                new ClassBased\ConstantChanged(
                                     new ClassConstantBased\OnlyPublicClassConstantChanged(
                                         new ClassConstantBased\MultipleChecksOnAClassConstant(
                                             new ClassConstantBased\ClassConstantVisibilityReduced(),
                                             new ClassConstantBased\ClassConstantValueChanged()
                                         )
-                                    ),
-                                    new ClassConstantBased\OnlyProtectedClassConstantChanged(
-                                        new ClassConstantBased\MultipleChecksOnAClassConstant(
-                                            new ClassConstantBased\ClassConstantVisibilityReduced(),
-                                            new ClassConstantBased\ClassConstantValueChanged()
-                                        )
                                     )
-                                )
-                            ),
-                            new ClassBased\PropertyChanged(
-                                new PropertyBased\MultipleChecksOnAProperty(
+                                ),
+                                new ClassBased\PropertyChanged(
                                     new PropertyBased\OnlyPublicPropertyChanged(
                                         new PropertyBased\MultipleChecksOnAProperty(
                                             new PropertyBased\PropertyDocumentedTypeChanged(),
@@ -103,19 +179,9 @@ use function file_exists;
                                             new PropertyBased\PropertyVisibilityReduced(),
                                             new PropertyBased\PropertyScopeChanged()
                                         )
-                                    ),
-                                    new PropertyBased\OnlyProtectedPropertyChanged(
-                                        new PropertyBased\MultipleChecksOnAProperty(
-                                            new PropertyBased\PropertyDocumentedTypeChanged(),
-                                            new PropertyBased\PropertyDefaultValueChanged(),
-                                            new PropertyBased\PropertyVisibilityReduced(),
-                                            new PropertyBased\PropertyScopeChanged()
-                                        )
                                     )
-                                )
-                            ),
-                            new ClassBased\MethodChanged(
-                                new MethodBased\MultipleChecksOnAMethod(
+                                ),
+                                new ClassBased\MethodChanged(
                                     new MethodBased\OnlyPublicMethodChanged(
                                         new MethodBased\MultipleChecksOnAMethod(
                                             new MethodBased\MethodBecameFinal(),
@@ -129,72 +195,8 @@ use function file_exists;
                                                     new FunctionBased\RequiredParameterAmountIncreased(),
                                                     new FunctionBased\ParameterDefaultValueChanged(),
                                                     new FunctionBased\ReturnTypeCovarianceChanged(new TypeIsCovariant()),
-                                                    new FunctionBased\ReturnTypeChanged(),
-                                                    new FunctionBased\ParameterTypeContravarianceChanged(new TypeIsContravariant()),
-                                                    new FunctionBased\ParameterTypeChanged()
+                                                    new FunctionBased\ParameterTypeContravarianceChanged(new TypeIsContravariant())
                                                 )
-                                            )
-                                        )
-                                    ),
-                                    new MethodBased\OnlyProtectedMethodChanged(
-                                        new MethodBased\MultipleChecksOnAMethod(
-                                            new MethodBased\MethodBecameFinal(),
-                                            new MethodBased\MethodConcretenessChanged(),
-                                            new MethodBased\MethodScopeChanged(),
-                                            new MethodBased\MethodVisibilityReduced(),
-                                            new MethodBased\MethodFunctionDefinitionChanged(
-                                                new FunctionBased\MultipleChecksOnAFunction(
-                                                    new FunctionBased\ParameterByReferenceChanged(),
-                                                    new FunctionBased\ReturnTypeByReferenceChanged(),
-                                                    new FunctionBased\RequiredParameterAmountIncreased(),
-                                                    new FunctionBased\ParameterDefaultValueChanged(),
-                                                    new FunctionBased\ReturnTypeCovarianceChanged(new TypeIsCovariant()),
-                                                    new FunctionBased\ReturnTypeChanged(),
-                                                    new FunctionBased\ParameterTypeContravarianceChanged(new TypeIsContravariant()),
-                                                    new FunctionBased\ParameterTypeChanged()
-                                                )
-                                            )
-                                        )
-                                    )
-                                )
-                            )
-                        )
-                    ),
-                    new ClassBased\FinalClassChanged(
-                        new ClassBased\MultipleChecksOnAClass(
-                            new ClassBased\ConstantChanged(
-                                new ClassConstantBased\OnlyPublicClassConstantChanged(
-                                    new ClassConstantBased\MultipleChecksOnAClassConstant(
-                                        new ClassConstantBased\ClassConstantVisibilityReduced(),
-                                        new ClassConstantBased\ClassConstantValueChanged()
-                                    )
-                                )
-                            ),
-                            new ClassBased\PropertyChanged(
-                                new PropertyBased\OnlyPublicPropertyChanged(
-                                    new PropertyBased\MultipleChecksOnAProperty(
-                                        new PropertyBased\PropertyDocumentedTypeChanged(),
-                                        new PropertyBased\PropertyDefaultValueChanged(),
-                                        new PropertyBased\PropertyVisibilityReduced(),
-                                        new PropertyBased\PropertyScopeChanged()
-                                    )
-                                )
-                            ),
-                            new ClassBased\MethodChanged(
-                                new MethodBased\OnlyPublicMethodChanged(
-                                    new MethodBased\MultipleChecksOnAMethod(
-                                        new MethodBased\MethodBecameFinal(),
-                                        new MethodBased\MethodConcretenessChanged(),
-                                        new MethodBased\MethodScopeChanged(),
-                                        new MethodBased\MethodVisibilityReduced(),
-                                        new MethodBased\MethodFunctionDefinitionChanged(
-                                            new FunctionBased\MultipleChecksOnAFunction(
-                                                new FunctionBased\ParameterByReferenceChanged(),
-                                                new FunctionBased\ReturnTypeByReferenceChanged(),
-                                                new FunctionBased\RequiredParameterAmountIncreased(),
-                                                new FunctionBased\ParameterDefaultValueChanged(),
-                                                new FunctionBased\ReturnTypeCovarianceChanged(new TypeIsCovariant()),
-                                                new FunctionBased\ParameterTypeContravarianceChanged(new TypeIsContravariant())
                                             )
                                         )
                                     )

--- a/src/DetectChanges/BCBreak/ClassBased/ExcludeAnonymousClasses.php
+++ b/src/DetectChanges/BCBreak/ClassBased/ExcludeAnonymousClasses.php
@@ -9,9 +9,7 @@ use Roave\BetterReflection\Reflection\ReflectionClass;
 
 final class ExcludeAnonymousClasses implements ClassBased
 {
-    /**
-     * @var ClassBased
-     */
+    /** @var ClassBased */
     private $check;
 
     public function __construct(ClassBased $check)

--- a/src/DetectChanges/BCBreak/ClassBased/ExcludeAnonymousClasses.php
+++ b/src/DetectChanges/BCBreak/ClassBased/ExcludeAnonymousClasses.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BackwardCompatibility\DetectChanges\BCBreak\ClassBased;
+
+use Roave\BackwardCompatibility\Changes;
+use Roave\BetterReflection\Reflection\ReflectionClass;
+
+final class ExcludeAnonymousClasses implements ClassBased
+{
+    /**
+     * @var ClassBased
+     */
+    private $check;
+
+    public function __construct(ClassBased $check)
+    {
+        $this->check = $check;
+    }
+
+    public function __invoke(ReflectionClass $fromClass, ReflectionClass $toClass) : Changes
+    {
+        if ($fromClass->isAnonymous()) {
+            return Changes::empty();
+        }
+
+        return $this->check->__invoke($fromClass, $toClass);
+    }
+}

--- a/src/DetectChanges/BCBreak/FunctionBased/MultipleChecksOnAFunction.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/MultipleChecksOnAFunction.php
@@ -18,12 +18,12 @@ final class MultipleChecksOnAFunction implements FunctionBased
         $this->checks = $checks;
     }
 
-    public function __invoke(ReflectionFunctionAbstract $fromFunction, ReflectionFunctionAbstract $toClass) : Changes
+    public function __invoke(ReflectionFunctionAbstract $fromFunction, ReflectionFunctionAbstract $toFunction) : Changes
     {
         return array_reduce(
             $this->checks,
-            function (Changes $changes, FunctionBased $check) use ($fromFunction, $toClass) : Changes {
-                return $changes->mergeWith($check->__invoke($fromFunction, $toClass));
+            function (Changes $changes, FunctionBased $check) use ($fromFunction, $toFunction) : Changes {
+                return $changes->mergeWith($check->__invoke($fromFunction, $toFunction));
             },
             Changes::empty()
         );

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ExcludeAnonymousClassesTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ExcludeAnonymousClassesTest.php
@@ -12,13 +12,14 @@ use Roave\BackwardCompatibility\DetectChanges\BCBreak\ClassBased\ExcludeAnonymou
 use Roave\BetterReflection\BetterReflection;
 use Roave\BetterReflection\Reflector\ClassReflector;
 use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
+use function reset;
 
 final class ExcludeAnonymousClassesTest extends TestCase
 {
     public function testNormalClassesAreNotExcluded() : void
     {
-        $locator       = (new BetterReflection())->astLocator();
-        $reflector = new ClassReflector(new StringSourceLocator(
+        $locator        = (new BetterReflection())->astLocator();
+        $reflector      = new ClassReflector(new StringSourceLocator(
             <<<'PHP'
 <?php
 
@@ -28,7 +29,7 @@ PHP
             $locator
         ));
         $fromReflection = $reflector->reflect('ANormalClass');
-        $toReflection = $reflector->reflect('ANormalClass');
+        $toReflection   = $reflector->reflect('ANormalClass');
 
         /** @var ClassBased|MockObject $check */
         $check = $this->createMock(ClassBased::class);
@@ -43,8 +44,8 @@ PHP
 
     public function testAnonymousClassesAreExcluded() : void
     {
-        $locator       = (new BetterReflection())->astLocator();
-        $reflector = new ClassReflector(new StringSourceLocator(
+        $locator                  = (new BetterReflection())->astLocator();
+        $reflector                = new ClassReflector(new StringSourceLocator(
             <<<'PHP'
 <?php
 
@@ -53,7 +54,7 @@ PHP
             ,
             $locator
         ));
-        $allClasses = $reflector->getAllClasses();
+        $allClasses               = $reflector->getAllClasses();
         $anonymousClassReflection = reset($allClasses);
 
         /** @var ClassBased|MockObject $check */

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ExcludeAnonymousClassesTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ExcludeAnonymousClassesTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoaveTest\BackwardCompatibility\DetectChanges\BCBreak\ClassBased;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Roave\BackwardCompatibility\Changes;
+use Roave\BackwardCompatibility\DetectChanges\BCBreak\ClassBased\ClassBased;
+use Roave\BackwardCompatibility\DetectChanges\BCBreak\ClassBased\ExcludeAnonymousClasses;
+use Roave\BetterReflection\BetterReflection;
+use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
+
+final class ExcludeAnonymousClassesTest extends TestCase
+{
+    public function testNormalClassesAreNotExcluded() : void
+    {
+        $locator       = (new BetterReflection())->astLocator();
+        $reflector = new ClassReflector(new StringSourceLocator(
+            <<<'PHP'
+<?php
+
+class ANormalClass {}
+PHP
+            ,
+            $locator
+        ));
+        $fromReflection = $reflector->reflect('ANormalClass');
+        $toReflection = $reflector->reflect('ANormalClass');
+
+        /** @var ClassBased|MockObject $check */
+        $check = $this->createMock(ClassBased::class);
+        $check->expects(self::once())
+            ->method('__invoke')
+            ->with($fromReflection, $toReflection)
+            ->willReturn(Changes::empty());
+
+        $excluder = new ExcludeAnonymousClasses($check);
+        $excluder->__invoke($fromReflection, $toReflection);
+    }
+
+    public function testAnonymousClassesAreExcluded() : void
+    {
+        $locator       = (new BetterReflection())->astLocator();
+        $reflector = new ClassReflector(new StringSourceLocator(
+            <<<'PHP'
+<?php
+
+$anonClass = new class {};
+PHP
+            ,
+            $locator
+        ));
+        $allClasses = $reflector->getAllClasses();
+        $anonymousClassReflection = reset($allClasses);
+
+        /** @var ClassBased|MockObject $check */
+        $check = $this->createMock(ClassBased::class);
+        $check->expects(self::never())->method('__invoke');
+
+        $excluder = new ExcludeAnonymousClasses($check);
+        $excluder->__invoke($anonymousClassReflection, $anonymousClassReflection);
+    }
+}


### PR DESCRIPTION
Fixes #55 

Note: the issue specifies filtering out anonymous functions too, but we don't actually reflect on functions at all at the moment; it is all just `ClassBased`, `InterfaceBased` and `TraitBased` roots; plus the top level is the `CompareClasses` implementation...