### PR TITLE
#70 look for further `vendor/autoload.php` locations to support in-project-dev-dependency installations

### DIFF
--- a/bin/roave-backward-compatibility-check.php
+++ b/bin/roave-backward-compatibility-check.php
@@ -33,7 +33,7 @@ use function file_exists;
 use function getcwd;
 
 (function () : void {
-    (function () {
+    (function () : void {
         $autoloaderLocations = [
             __DIR__ . '/../vendor/autoload.php',
             __DIR__ . '/../autoload.php',


### PR DESCRIPTION
Closes #70 

I was trying to find a way to test this via `.travis.yml`, but the problem is that I'd need to add a composer `vcs` repository and then use a `HEAD` reference with some ugly hacks that will break everything, so I'd probably skip that for now.

@ciaranmcnulty can you please review this one? Use `?w=1` :-)