### PR TITLE
Check that from is actually provided

### DIFF
--- a/src/Command/AssertBackwardsCompatible.php
+++ b/src/Command/AssertBackwardsCompatible.php
@@ -148,7 +148,7 @@ USAGE
         // @todo fix flaky assumption about the path of the source repo...
         $sourceRepo = CheckedOutRepository::fromPath(getcwd());
 
-        $fromRevision = $input->hasOption('from')
+        $fromRevision = $input->hasParameterOption('from')
             ? $this->parseRevisionFromInput($input, $sourceRepo)
             : $this->determineFromRevisionFromRepository($sourceRepo, $stdErr);
 

--- a/test/unit/Command/AssertBackwardsCompatibleTest.php
+++ b/test/unit/Command/AssertBackwardsCompatibleTest.php
@@ -110,6 +110,7 @@ final class AssertBackwardsCompatibleTest extends TestCase
         $toSha   = sha1('toRevision', false);
 
         $this->input->expects(self::any())->method('hasOption')->willReturn(true);
+        $this->input->expects(self::any())->method('hasParameterOption')->willReturn(true);
         $this->input->expects(self::any())->method('getOption')->willReturnMap([
             ['from', $fromSha],
             ['to', $toSha],
@@ -160,6 +161,7 @@ final class AssertBackwardsCompatibleTest extends TestCase
         $toSha   = sha1('toRevision', false);
 
         $this->input->expects(self::any())->method('hasOption')->willReturn(true);
+        $this->input->expects(self::any())->method('hasParameterOption')->willReturn(true);
         $this->input->expects(self::any())->method('getOption')->willReturnMap([
             ['from', $fromSha],
             ['to', $toSha],
@@ -222,6 +224,7 @@ final class AssertBackwardsCompatibleTest extends TestCase
         $toSha   = sha1('toRevision', false);
 
         $this->input->expects(self::any())->method('hasOption')->willReturn(true);
+        $this->input->expects(self::any())->method('hasParameterOption')->willReturn(true);
         $this->input->expects(self::any())->method('getOption')->willReturnMap([
             ['from', $fromSha],
             ['to', $toSha],
@@ -349,6 +352,7 @@ final class AssertBackwardsCompatibleTest extends TestCase
         $toSha   = sha1('toRevision', false);
 
         $this->input->expects(self::any())->method('hasOption')->willReturn(true);
+        $this->input->expects(self::any())->method('hasParameterOption')->willReturn(true);
         $this->input->expects(self::any())->method('getOption')->willReturnMap([
             ['from', $fromSha],
             ['to', $toSha],


### PR DESCRIPTION
This addresses #72 - in my instance `hasOption` is returning true because its been replaced with its default value of `null`. 

I'm mildly surprised that this hasn't happened to anyone pre-release though - are you always specifying a revision? It's possible that this is a symfony version thing.

I stuck to the existing paradigm for the tests but there's a _lot_ of stubbing going on - it might be clearer to use a concrete ArgvInput (which would also have avoided the issue of stubbing enshrining an incorrect understanding of the API)

