### PR TITLE
Throw exception if repository does not contain any tagged version

### DIFF
--- a/src/Git/PickLastMinorVersionFromCollection.php
+++ b/src/Git/PickLastMinorVersionFromCollection.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BackwardCompatibility\Git;
 
+use Assert\Assert;
 use Symfony\Component\Process\Exception\LogicException;
 use Symfony\Component\Process\Exception\RuntimeException;
 use Version\Version;
@@ -20,6 +21,8 @@ final class PickLastMinorVersionFromCollection implements PickVersionFromVersion
      */
     public function forVersions(VersionsCollection $versions) : Version
     {
+        Assert::that(count($versions))->greaterThan(0, 'Repository must have at least one version tag.');
+
         $versions->sort(VersionsCollection::SORT_DESC);
 
         /** @var Version[] $versionsAsArray */

--- a/test/unit/Git/PickLastMinorVersionFromCollectionTest.php
+++ b/test/unit/Git/PickLastMinorVersionFromCollectionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace RoaveTest\BackwardCompatibility\Git;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Roave\BackwardCompatibility\Git\PickLastMinorVersionFromCollection;
 use Version\Version;
@@ -42,5 +43,12 @@ final class PickLastMinorVersionFromCollectionTest extends TestCase
                 }, $collectionOfVersions))
             )->getVersionString()
         );
+    }
+
+    public function testFailsIfNoVersionGiven() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new PickLastMinorVersionFromCollection())->forVersions(new VersionsCollection());
     }
 }


### PR DESCRIPTION
Hi,
I spend a while debugging failing Travis build which uses roave-backward-compatibility-check, because I was getting this error:

```
PHP Fatal error:  Uncaught TypeError: Return value of Roave\BackwardCompatibility\Git\PickLastMinorVersionFromCollection::forVersions() must be an instance of Version\Version, boolean returned in /.../src/Git/PickLastMinorVersionFromCollection.php:43
Stack trace:
#0 /.../src/Command/AssertBackwardsCompatible.php(230): Roave\BackwardCompatibility\Git\PickLastMinorVersionFromCollection->forVersions(Object(Version\VersionsCollection))
#1 /.../src/Command/AssertBackwardsCompatible.php(153): Roave\BackwardCompatibility\Command\AssertBackwardsCompatible->determineFromRevisionFromRepository(Object(Roave\BackwardCompatibility\Git\CheckedOutRepository), Object(Symfony\Component\Console\Output\StreamOutput))
#2 /.../vendor/symfony/console/Command/Command.php(251): Roave\BackwardCompatibility\Command\AssertBackwardsCompatible->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symf in /srv/www/test/BackwardCompatibilityCheck/src/Git/PickLastMinorVersionFromCollection.php on line 43
```

which was really confusing. After some debugging I finally realized this was caused by running the check on a fork, which does not have any tags pushed.

This is why I suggest something like this, to make it clear what was the reason of failure in case repository does not contain any tagged versions.

What do you think?