### PR TITLE
Build PHAR using BOX and use Travis to publish PHAR releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
-vendor
-infection-log.txt
+/vendor
+/infection-log.txt
+/box.json
+/box.phar
+/dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,15 @@ before_script:
 git:
   depth: 99999
 
+deploy:
+  provider: releases
+  api_key:
+    secure: $DEPLOY_TOKEN_SECURE
+  file: dist/roave-backward-compatibility-check.phar
+  skip_cleanup: true
+  on:
+    tags: true
+
 jobs:
   include:
 
@@ -47,6 +56,10 @@ jobs:
     - stage: Verify BC Breaks
       php: 7.2
       script: bin/roave-backward-compatibility-check --from=master --to=HEAD
+
+    - stage: Build release PHAR
+      php: 7.2
+      script: ./build-phar.sh
 
 cache:
   directories:

--- a/box.json.dist
+++ b/box.json.dist
@@ -1,0 +1,15 @@
+{
+    "compactors": [
+        "Herrera\\Box\\Compactor\\Php",
+        "Herrera\\Box\\Compactor\\Json"
+    ],
+    "compression": "GZ",
+    "main": "bin/roave-backward-compatibility-check.php",
+    "output": "dist/roave-backward-compatibility-check.phar",
+    "files-bin": [
+        "LICENSE",
+        "vendor/composer/composer/LICENSE"
+    ],
+    "chmod": "0755",
+    "git-version": "git-version"
+}

--- a/build-phar.sh
+++ b/build-phar.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+if [ ! -f box.phar ]; then
+    wget https://github.com/humbug/box/releases/download/3.0.0-beta.4/box.phar -O box.phar
+fi
+
+# lock PHP to minimum allowed version
+composer config platform.php 7.2.0
+composer update --no-dev
+
+php box.phar compile
+
+git checkout composer.*
+composer install


### PR DESCRIPTION
The PHAR builds fine, but running it throws really weird errors. Maybe @theofidry can help? :/

```
$ dist/roave-backward-compatibility-check.phar r:a --from 1.0.0
Comparing from 81b1ab0128e72ee8e2666b28abcedadff84fcc23 to 95b5c0d5ac37ff7cfeac8368ec7f0b3009d6fd09...
Loading composer repositories with package information
Installing dependencies from lock file
Package operations: 24 installs, 0 updates, 0 removals
  - Installing beberlei/assert (v2.9.5): Loading from cache
  - Installing symfony/process (v4.0.11): Loading from cache
  - Installing symfony/finder (v4.0.11): Loading from cache
  - Installing symfony/polyfill-ctype (v1.8.0): Loading from cache
  - Installing symfony/filesystem (v4.0.11): Loading from cache
  - Installing symfony/polyfill-mbstring (v1.8.0): Loading from cache
  - Installing symfony/console (v4.0.11): Loading from cache
  - Installing seld/phar-utils (1.0.1): Loading from cache
  - Installing seld/jsonlint (1.7.1): Loading from cache
  - Installing seld/cli-prompt (1.0.3): Loading from cache
  - Installing psr/log (1.0.2): Loading from cache
  - Installing justinrainbow/json-schema (5.2.7): Loading from cache
  - Installing composer/spdx-licenses (1.4.0): Loading from cache
  - Installing composer/semver (1.4.2): Loading from cache
  - Installing composer/ca-bundle (1.1.1): Loading from cache
  - Installing composer/composer (1.6.5): Loading from cache
  - Installing nikolaposa/version (3.0.1): Loading from cache
  - Installing phpdocumentor/reflection-common (1.0.1): Loading from cache
  - Installing roave/signature (1.0.0): Loading from cache
  - Installing phpdocumentor/type-resolver (0.4.0): Loading from cache
  - Installing webmozart/assert (1.3.0): Loading from cache
  - Installing phpdocumentor/reflection-docblock (4.3.0): Loading from cache
  - Installing nikic/php-parser (v4.0.1): Loading from cache
  - Installing roave/better-reflection (3.0.0): Loading from cache
Generating optimized autoload files
PHP Warning:  fopen(phar:///www/roave/BackwardCompatibilityCheck/dist/roave-backward-compatibility-check.phar/vendor/composer/composer/src/Composer/Autoload/../../../LICENSE): failed to open stream: phar error: "vendor/composer/composer/LICENSE" is not a file in phar "/www/roave/BackwardCompatibilityCheck/dist/roave-backward-compatibility-check.phar" in phar:///www/roave/BackwardCompatibilityCheck/dist/roave-backward-compatibility-check.phar/vendor/composer/composer/src/Composer/Autoload/AutoloadGenerator.php on line 1002

Warning: fopen(phar:///www/roave/BackwardCompatibilityCheck/dist/roave-backward-compatibility-check.phar/vendor/composer/composer/src/Composer/Autoload/../../../LICENSE): failed to open stream: phar error: "vendor/composer/composer/LICENSE" is not a file in phar "/www/roave/BackwardCompatibilityCheck/dist/roave-backward-compatibility-check.phar" in phar:///www/roave/BackwardCompatibilityCheck/dist/roave-backward-compatibility-check.phar/vendor/composer/composer/src/Composer/Autoload/AutoloadGenerator.php on line 1002
PHP Warning:  stream_copy_to_stream() expects parameter 1 to be resource, boolean given in phar:///www/roave/BackwardCompatibilityCheck/dist/roave-backward-compatibility-check.phar/vendor/composer/composer/src/Composer/Autoload/AutoloadGenerator.php on line 1005

Warning: stream_copy_to_stream() expects parameter 1 to be resource, boolean given in phar:///www/roave/BackwardCompatibilityCheck/dist/roave-backward-compatibility-check.phar/vendor/composer/composer/src/Composer/Autoload/AutoloadGenerator.php on line 1005
PHP Warning:  fclose() expects parameter 1 to be resource, boolean given in phar:///www/roave/BackwardCompatibilityCheck/dist/roave-backward-compatibility-check.phar/vendor/composer/composer/src/Composer/Autoload/AutoloadGenerator.php on line 1006

Warning: fclose() expects parameter 1 to be resource, boolean given in phar:///www/roave/BackwardCompatibilityCheck/dist/roave-backward-compatibility-check.phar/vendor/composer/composer/src/Composer/Autoload/AutoloadGenerator.php on line 1006
Loading composer repositories with package information
Installing dependencies from lock file
Package operations: 24 installs, 0 updates, 0 removals
  - Installing beberlei/assert (v2.9.5): Loading from cache
  - Installing symfony/process (v4.0.11): Loading from cache
  - Installing symfony/finder (v4.0.11): Loading from cache
  - Installing symfony/polyfill-ctype (v1.8.0): Loading from cache
  - Installing symfony/filesystem (v4.0.11): Loading from cache
  - Installing symfony/polyfill-mbstring (v1.8.0): Loading from cache
  - Installing symfony/console (v4.0.11): Loading from cache
  - Installing seld/phar-utils (1.0.1): Loading from cache
  - Installing seld/jsonlint (1.7.1): Loading from cache
  - Installing seld/cli-prompt (1.0.3): Loading from cache
  - Installing psr/log (1.0.2): Loading from cache
  - Installing justinrainbow/json-schema (5.2.7): Loading from cache
  - Installing composer/spdx-licenses (1.4.0): Loading from cache
  - Installing composer/semver (1.4.2): Loading from cache
  - Installing composer/ca-bundle (1.1.1): Loading from cache
  - Installing composer/composer (1.6.5): Loading from cache
  - Installing nikolaposa/version (3.0.1): Loading from cache
  - Installing phpdocumentor/reflection-common (1.0.1): Loading from cache
  - Installing roave/signature (1.0.0): Loading from cache
  - Installing phpdocumentor/type-resolver (0.4.0): Loading from cache
  - Installing webmozart/assert (1.3.0): Loading from cache
  - Installing phpdocumentor/reflection-docblock (4.3.0): Loading from cache
  - Installing nikic/php-parser (v4.0.1): Loading from cache
  - Installing roave/better-reflection (3.0.0): Loading from cache
Generating optimized autoload files
PHP Warning:  fopen(phar:///www/roave/BackwardCompatibilityCheck/dist/roave-backward-compatibility-check.phar/vendor/composer/composer/src/Composer/Autoload/../../../LICENSE): failed to open stream: phar error: "vendor/composer/composer/LICENSE" is not a file in phar "/www/roave/BackwardCompatibilityCheck/dist/roave-backward-compatibility-check.phar" in phar:///www/roave/BackwardCompatibilityCheck/dist/roave-backward-compatibility-check.phar/vendor/composer/composer/src/Composer/Autoload/AutoloadGenerator.php on line 1002

Warning: fopen(phar:///www/roave/BackwardCompatibilityCheck/dist/roave-backward-compatibility-check.phar/vendor/composer/composer/src/Composer/Autoload/../../../LICENSE): failed to open stream: phar error: "vendor/composer/composer/LICENSE" is not a file in phar "/www/roave/BackwardCompatibilityCheck/dist/roave-backward-compatibility-check.phar" in phar:///www/roave/BackwardCompatibilityCheck/dist/roave-backward-compatibility-check.phar/vendor/composer/composer/src/Composer/Autoload/AutoloadGenerator.php on line 1002
PHP Warning:  stream_copy_to_stream() expects parameter 1 to be resource, boolean given in phar:///www/roave/BackwardCompatibilityCheck/dist/roave-backward-compatibility-check.phar/vendor/composer/composer/src/Composer/Autoload/AutoloadGenerator.php on line 1005

Warning: stream_copy_to_stream() expects parameter 1 to be resource, boolean given in phar:///www/roave/BackwardCompatibilityCheck/dist/roave-backward-compatibility-check.phar/vendor/composer/composer/src/Composer/Autoload/AutoloadGenerator.php on line 1005
PHP Warning:  fclose() expects parameter 1 to be resource, boolean given in phar:///www/roave/BackwardCompatibilityCheck/dist/roave-backward-compatibility-check.phar/vendor/composer/composer/src/Composer/Autoload/AutoloadGenerator.php on line 1006

Warning: fclose() expects parameter 1 to be resource, boolean given in phar:///www/roave/BackwardCompatibilityCheck/dist/roave-backward-compatibility-check.phar/vendor/composer/composer/src/Composer/Autoload/AutoloadGenerator.php on line 1006
No backwards-incompatible changes detected
```

closes #23