### PR TITLE
Turn on checks for mixed types

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3146,16 +3146,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "2.0.1",
+            "version": "2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "2d6eab85fa8b5185801ff6e4362523da658a2431"
+                "reference": "beeab32f60dcff5959f0578d2893ecb6466fd460"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/2d6eab85fa8b5185801ff6e4362523da658a2431",
-                "reference": "2d6eab85fa8b5185801ff6e4362523da658a2431",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/beeab32f60dcff5959f0578d2893ecb6466fd460",
+                "reference": "beeab32f60dcff5959f0578d2893ecb6466fd460",
                 "shasum": ""
             },
             "require": {
@@ -3201,7 +3201,7 @@
                 "inspection",
                 "php"
             ],
-            "time": "2018-05-24T18:33:41+00:00"
+            "time": "2018-06-30T20:21:29+00:00"
         }
     ],
     "aliases": [],

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     name="Example Psalm config with recommended defaults"
     useDocblockTypes="true"
-    totallyTyped="false"
+    totallyTyped="true"
     allowPhpStormGenerics="true"
 >
     <projectFiles>
@@ -13,6 +13,27 @@
     </projectFiles>
 
     <issueHandlers>
-        <PropertyNotSetInConstructor errorLevel="suppress"/>
+        <PropertyNotSetInConstructor>
+            <errorLevel type="suppress">
+                <file name="src/Git/CheckedOutRepository.php" />
+                <file name="src/Git/Revision.php" />
+                <file name="src/Changes.php" />
+            </errorLevel>
+        </PropertyNotSetInConstructor>
+
+        <MixedAssignment>
+            <errorLevel type="suppress">
+                <file name="src/DetectChanges/BCBreak/ClassConstantBased/ClassConstantValueChanged.php" />
+                <file name="src/DetectChanges/BCBreak/FunctionBased/ParameterDefaultValueChanged.php" />
+                <file name="src/DetectChanges/BCBreak/PropertyBased/PropertyDefaultValueChanged.php" />
+                <file name="src/LocateDependencies/LocateDependenciesViaComposer.php" />
+            </errorLevel>
+        </MixedAssignment>
+
+        <MixedArgument>
+            <errorLevel type="suppress">
+                <file name="src/LocateDependencies/LocateDependenciesViaComposer.php" />
+            </errorLevel>
+        </MixedArgument>
     </issueHandlers>
 </psalm>

--- a/src/Changes.php
+++ b/src/Changes.php
@@ -23,6 +23,7 @@ final class Changes implements IteratorAggregate, Countable
         static $empty;
 
         if ($empty) {
+            /** @var self $empty */
             return $empty;
         }
 

--- a/src/Command/AssertBackwardsCompatible.php
+++ b/src/Command/AssertBackwardsCompatible.php
@@ -152,8 +152,8 @@ USAGE
             ? $this->parseRevisionFromInput($input, $sourceRepo)
             : $this->determineFromRevisionFromRepository($sourceRepo, $stdErr);
 
-        $toRevision  = $this->parseRevision->fromStringForRepository($input->getOption('to'), $sourceRepo);
-        $sourcesPath = $input->getArgument('sources-path');
+        $toRevision  = $this->parseRevision->fromStringForRepository((string) $input->getOption('to'), $sourceRepo);
+        $sourcesPath = (string) $input->getArgument('sources-path');
 
         $stdErr->writeln(sprintf('Comparing from %s to %s...', (string) $fromRevision, (string) $toRevision));
 
@@ -184,6 +184,7 @@ USAGE
 
             (new SymfonyConsoleTextFormatter($stdErr))->write($changes);
 
+            /** @var string[] $outputFormats */
             $outputFormats = $input->getOption('format') ?: [];
             Assert::that($outputFormats)->isArray();
 

--- a/src/DetectChanges/BCBreak/FunctionBased/ParameterByReferenceChanged.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/ParameterByReferenceChanged.php
@@ -30,9 +30,9 @@ final class ParameterByReferenceChanged implements FunctionBased
 
     public function __invoke(ReflectionFunctionAbstract $fromFunction, ReflectionFunctionAbstract $toFunction) : Changes
     {
-        /** @var ReflectionParameter[] $fromParameters */
+        /** @var array<int, ReflectionParameter> $fromParameters */
         $fromParameters = array_values($fromFunction->getParameters());
-        /** @var ReflectionParameter[] $toParameters */
+        /** @var array<int, ReflectionParameter> $toParameters */
         $toParameters = array_values($toFunction->getParameters());
 
         $changes = Changes::empty();

--- a/src/DetectChanges/BCBreak/FunctionBased/ParameterDefaultValueChanged.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/ParameterDefaultValueChanged.php
@@ -64,7 +64,7 @@ final class ParameterDefaultValueChanged implements FunctionBased
         return $changes;
     }
 
-    /** @return ReflectionParameter[] indexed by parameter index */
+    /** @return array<int, ReflectionParameter> indexed by parameter index */
     private function defaultParameterValues(ReflectionFunctionAbstract $function) : array
     {
         $optionalParameters = array_values(array_filter(

--- a/src/DetectChanges/BCBreak/FunctionBased/ParameterTypeChanged.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/ParameterTypeChanged.php
@@ -32,9 +32,9 @@ final class ParameterTypeChanged implements FunctionBased
 
     public function __invoke(ReflectionFunctionAbstract $fromFunction, ReflectionFunctionAbstract $toFunction) : Changes
     {
-        /** @var ReflectionParameter[] $fromParameters */
+        /** @var array<int, ReflectionParameter> $fromParameters */
         $fromParameters = array_values($fromFunction->getParameters());
-        /** @var ReflectionParameter[] $toParameters */
+        /** @var array<int, ReflectionParameter> $toParameters */
         $toParameters = array_values($toFunction->getParameters());
 
         $changes = Changes::empty();

--- a/src/DetectChanges/BCBreak/FunctionBased/ParameterTypeContravarianceChanged.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/ParameterTypeContravarianceChanged.php
@@ -35,9 +35,9 @@ final class ParameterTypeContravarianceChanged implements FunctionBased
 
     public function __invoke(ReflectionFunctionAbstract $fromFunction, ReflectionFunctionAbstract $toFunction) : Changes
     {
-        /** @var ReflectionParameter[] $fromParameters */
+        /** @var array<int, ReflectionParameter> $fromParameters */
         $fromParameters = array_values($fromFunction->getParameters());
-        /** @var ReflectionParameter[] $toParameters */
+        /** @var array<int, ReflectionParameter> $toParameters */
         $toParameters = array_values($toFunction->getParameters());
 
         $changes = Changes::empty();

--- a/src/Formatter/MarkdownPipedToSymfonyConsoleFormatter.php
+++ b/src/Formatter/MarkdownPipedToSymfonyConsoleFormatter.php
@@ -25,6 +25,7 @@ final class MarkdownPipedToSymfonyConsoleFormatter implements OutputFormatter
 
     public function write(Changes $changes) : void
     {
+        /** @var Change[] $arrayOfChanges */
         $arrayOfChanges = $changes->getIterator()->getArrayCopy();
 
         $this->output->writeln(

--- a/src/Git/GitCheckoutRevisionToTemporaryPath.php
+++ b/src/Git/GitCheckoutRevisionToTemporaryPath.php
@@ -15,9 +15,15 @@ use function uniqid;
 
 final class GitCheckoutRevisionToTemporaryPath implements PerformCheckoutOfRevision
 {
-    /** @var callable */
+    /**
+     * @psalm-var callable(string):string
+     * @var callable
+     */
     private $uniquenessFunction;
 
+    /**
+     * @psalm-param null|callable(string):string $uniquenessFunction
+     */
     public function __construct(?callable $uniquenessFunction = null)
     {
         $this->uniquenessFunction = $uniquenessFunction ?? function (string $nonUniqueThing) : string {

--- a/src/LocateDependencies/LocateDependenciesViaComposer.php
+++ b/src/LocateDependencies/LocateDependenciesViaComposer.php
@@ -29,9 +29,15 @@ final class LocateDependenciesViaComposer implements LocateDependencies
     /** @var Locator */
     private $astLocator;
 
-    /** @var callable */
+    /**
+     * @psalm-var callable(string):Installer
+     * @var callable
+     */
     private $makeComposerInstaller;
 
+    /**
+     * @psalm-param callable(string):Installer $makeComposerInstaller
+     */
     public function __construct(
         callable $makeComposerInstaller,
         Locator $astLocator
@@ -92,6 +98,7 @@ final class LocateDependenciesViaComposer implements LocateDependencies
         Assert::that($classMapProperty)->notNull();
 
         assert($classMapProperty instanceof ReflectionProperty);
+        /** @var string[] $classMap */
         $classMap = $classMapProperty->getDefaultValue();
 
         Assert::that($classMap)


### PR DESCRIPTION
This PR attempts to eradicate any `mixed` types in this codebase. It does this with the help of Psalm's `totallyTyped="true"` config.