### PR TITLE
fix: detect the auto-loader of the project you're installed in

### DIFF
--- a/bin/roave-backward-compatibility-check.php
+++ b/bin/roave-backward-compatibility-check.php
@@ -38,6 +38,7 @@ use function getcwd;
             __DIR__ . '/../vendor/autoload.php',
             __DIR__ . '/../autoload.php',
             __DIR__ . '/../../autoload.php',
+            __DIR__ . '/../../../autoload.php',
             getcwd() . '/vendor/autoload.php',
         ];
 


### PR DESCRIPTION
Relative to `roave/backward-compatibility-check/bin/`

Visible if installed using `composer-bin`.