### PR TITLE
#98 remove `StubClassSourceLocator` from default setup

### DIFF
--- a/src/LocateDependencies/LocateDependenciesViaComposer.php
+++ b/src/LocateDependencies/LocateDependenciesViaComposer.php
@@ -7,7 +7,6 @@ namespace Roave\BackwardCompatibility\LocateDependencies;
 use Assert\Assert;
 use Composer\Installer;
 use Roave\BackwardCompatibility\SourceLocator\StaticClassMapSourceLocator;
-use Roave\BackwardCompatibility\SourceLocator\StubClassSourceLocator;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionProperty;
 use Roave\BetterReflection\Reflector\ClassReflector;
@@ -81,7 +80,6 @@ final class LocateDependenciesViaComposer implements LocateDependencies
             $this->sourceLocatorFromAutoloadStatic($generatedAutoloadClass),
             $this->sourceLocatorFromAutoloadFiles($generatedAutoloadClass),
             new PhpInternalSourceLocator($this->astLocator),
-            new StubClassSourceLocator($this->astLocator),
         ]);
     }
 

--- a/src/SourceLocator/StubClassSourceLocator.php
+++ b/src/SourceLocator/StubClassSourceLocator.php
@@ -13,6 +13,12 @@ use function explode;
 use function implode;
 use function sprintf;
 
+/**
+ * @deprecated do not use: this locator was initially designed to have all classes stubbed out when they
+ *             cannot be found. This is no longer the case since version 1.1.0 of the library, since
+ *             classes that could not be located just lead to a new {@see \Roave\BackwardCompatibility\Change}
+ *             instance, with a BC break being reported.
+ */
 final class StubClassSourceLocator extends AbstractSourceLocator
 {
     /**

--- a/test/e2e/Command/AssertBackwardsCompatibleTest.php
+++ b/test/e2e/Command/AssertBackwardsCompatibleTest.php
@@ -34,6 +34,10 @@ JSON;
 
 namespace TestArtifact;
 
+interface A {}
+interface B {}
+interface C {}
+
 final class TheClass
 {
     public function method(A $a)
@@ -47,6 +51,10 @@ PHP
 <?php
 
 namespace TestArtifact;
+
+interface A {}
+interface B {}
+interface C {}
 
 final class TheClass
 {
@@ -62,6 +70,10 @@ PHP
 
 namespace TestArtifact;
 
+interface A {}
+interface B {}
+interface C {}
+
 final class TheClass
 {
     public function method(C $a)
@@ -76,6 +88,10 @@ PHP
 <?php
 
 namespace TestArtifact;
+
+interface A {}
+interface B {}
+interface C {}
 
 final class TheClass
 {

--- a/test/unit/LocateDependencies/LocateDependenciesViaComposerTest.php
+++ b/test/unit/LocateDependencies/LocateDependenciesViaComposerTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Roave\BackwardCompatibility\LocateDependencies\LocateDependenciesViaComposer;
 use Roave\BackwardCompatibility\SourceLocator\StaticClassMapSourceLocator;
-use Roave\BackwardCompatibility\SourceLocator\StubClassSourceLocator;
 use Roave\BetterReflection\BetterReflection;
 use Roave\BetterReflection\SourceLocator\Ast\Locator;
 use Roave\BetterReflection\SourceLocator\Type\AggregateSourceLocator;
@@ -123,7 +122,7 @@ final class LocateDependenciesViaComposerTest extends TestCase
 
         $locators = $reflectionLocators->getValue($locator);
 
-        self::assertCount(4, $locators);
+        self::assertCount(3, $locators);
         self::assertEquals(
             new StaticClassMapSourceLocator(
                 [
@@ -148,7 +147,6 @@ final class LocateDependenciesViaComposerTest extends TestCase
             $locators[1]
         );
         self::assertInstanceOf(PhpInternalSourceLocator::class, $locators[2]);
-        self::assertInstanceOf(StubClassSourceLocator::class, $locators[3]);
     }
 
     public function testWillLocateDependenciesEvenWithoutAutoloadFiles() : void
@@ -175,7 +173,7 @@ final class LocateDependenciesViaComposerTest extends TestCase
 
         $locators = $reflectionLocators->getValue($locator);
 
-        self::assertCount(4, $locators);
+        self::assertCount(3, $locators);
         self::assertEquals(
             new StaticClassMapSourceLocator(
                 [
@@ -188,7 +186,6 @@ final class LocateDependenciesViaComposerTest extends TestCase
         );
         self::assertEquals(new AggregateSourceLocator(), $locators[1]);
         self::assertInstanceOf(PhpInternalSourceLocator::class, $locators[2]);
-        self::assertInstanceOf(StubClassSourceLocator::class, $locators[3]);
     }
 
     private function realpath(string $path) : string


### PR DESCRIPTION
This effectively reverts #74 without introducing a BC break: the class
is now deprecated, but still exists in the codebase.

The idea of the `StubClassSourceLocator` was that it should be possible
to analyse code even if dependency holes are present, but that is now
solved by skipping BC break checks for any reflection-based exception.

This massively simplifies things, as any missing dependency will simply
lead to a skipped error and a non-zero exit code, much like it happens
in `maglnet/composer-require-checker` (https://github.com/maglnet/ComposerRequireChecker).

This also fixes weird scenarios where a pre-existing class is being
looked up in a new codebase that doesn't contain it. Assuming that
following was deleted across two breaking versions:

```php
namespace Foo;
interface Bar {}
```

Before this change, this breakage would not be located, because the
`StubClassSourceLocator` would create an implicit `Foo\Bar` stub, which
would therefore be considered as "not a change".