### PR TITLE
Update to doctrine/cs v5

### DIFF
--- a/bin/roave-backward-compatibility-check.php
+++ b/bin/roave-backward-compatibility-check.php
@@ -32,8 +32,8 @@ use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use function file_exists;
 
-(function () : void {
-    (function () : void {
+(static function () : void {
+    (static function () : void {
         $autoloaderLocations = [
             __DIR__ . '/../vendor/autoload.php', // Installed by cloning the project and running `composer install`
             __DIR__ . '/../../../autoload.php',  // Installed via `composer require`
@@ -65,7 +65,7 @@ use function file_exists;
         new GetVersionCollectionFromGitRepository(),
         new PickLastMinorVersionFromCollection(),
         new LocateDependenciesViaComposer(
-            function (string $installationPath) use ($composerIo) : Installer {
+            static function (string $installationPath) use ($composerIo) : Installer {
                 return Installer::create(
                     $composerIo,
                     (new Factory())->createComposer(

--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
         }
     ],
     "require-dev": {
-        "doctrine/coding-standard": "^4.0",
+        "doctrine/coding-standard": "^5.0",
         "infection/infection": "^0.9.1",
         "phpstan/phpstan": "^0.10.3",
         "phpstan/phpstan-beberlei-assert": "^0.10",
         "phpstan/phpstan-phpunit": "^0.10",
         "phpunit/phpunit": "^7.0",
         "roave/security-advisories": "dev-master",
-        "squizlabs/php_codesniffer": "^3.2",
+        "squizlabs/php_codesniffer": "^3.4",
         "vimeo/psalm": "^2.0"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "96297e401518728939d9769f6ce95c85",
+    "content-hash": "eb483a2a66dc9e900efc1a3bb764309d",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1313,29 +1313,27 @@
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.4.4",
+            "version": "v0.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08"
+                "reference": "e749410375ff6fb7a040a68878c656c2e610b132"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/2e41850d5f7797cbb1af7b030d245b3b24e63a08",
-                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/e749410375ff6fb7a040a68878c656c2e610b132",
+                "reference": "e749410375ff6fb7a040a68878c656c2e610b132",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0",
                 "php": "^5.3|^7",
-                "squizlabs/php_codesniffer": "*"
+                "squizlabs/php_codesniffer": "^2|^3"
             },
             "require-dev": {
                 "composer/composer": "*",
-                "wimg/php-compatibility": "^8.0"
-            },
-            "suggest": {
-                "dealerdirect/qa-tools": "All the PHP QA tools you'll need"
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -1353,13 +1351,13 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
-                    "email": "f.nijhof@dealerdirect.nl",
-                    "homepage": "http://workingatdealerdirect.eu",
-                    "role": "Developer"
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://workingatdealerdirect.eu",
+            "homepage": "http://www.dealerdirect.com",
             "keywords": [
                 "PHPCodeSniffer",
                 "PHP_CodeSniffer",
@@ -1377,32 +1375,32 @@
                 "stylecheck",
                 "tests"
             ],
-            "time": "2017-12-06T16:27:17+00:00"
+            "time": "2018-10-26T13:21:45+00:00"
         },
         {
             "name": "doctrine/coding-standard",
-            "version": "4.0.0",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/coding-standard.git",
-                "reference": "0469c18a1a4724c278f2879c0dd7b1fa860b52de"
+                "reference": "9017efe98b47329cbd895d43f596747c8ef27307"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/coding-standard/zipball/0469c18a1a4724c278f2879c0dd7b1fa860b52de",
-                "reference": "0469c18a1a4724c278f2879c0dd7b1fa860b52de",
+                "url": "https://api.github.com/repos/doctrine/coding-standard/zipball/9017efe98b47329cbd895d43f596747c8ef27307",
+                "reference": "9017efe98b47329cbd895d43f596747c8ef27307",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.2",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
                 "php": "^7.1",
-                "slevomat/coding-standard": "^4.5.0",
-                "squizlabs/php_codesniffer": "^3.2.3"
+                "slevomat/coding-standard": "^4.8.0",
+                "squizlabs/php_codesniffer": "^3.3.2"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "5.0.x-dev"
                 }
             },
             "autoload": {
@@ -1424,18 +1422,21 @@
                     "email": "st.mueller@dzh-online.de"
                 }
             ],
-            "description": "Doctrine Coding Standard",
-            "homepage": "http://www.doctrine-project.org",
+            "description": "The Doctrine Coding Standard is a set of PHPCS rules applied to all Doctrine projects.",
+            "homepage": "https://www.doctrine-project.org/projects/coding-standard.html",
             "keywords": [
+                "checks",
                 "code",
                 "coding",
                 "cs",
                 "doctrine",
+                "rules",
                 "sniffer",
+                "sniffs",
                 "standard",
                 "style"
             ],
-            "time": "2018-03-03T23:49:15+00:00"
+            "time": "2019-01-31T13:22:30+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -4014,21 +4015,21 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "4.6.3",
+            "version": "4.8.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "76e31b7cb2ce1de53b36430a332daae2db0be549"
+                "reference": "bff96313d8c7c2ba57a4edb13c1c141df8988c58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/76e31b7cb2ce1de53b36430a332daae2db0be549",
-                "reference": "76e31b7cb2ce1de53b36430a332daae2db0be549",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/bff96313d8c7c2ba57a4edb13c1c141df8988c58",
+                "reference": "bff96313d8c7c2ba57a4edb13c1c141df8988c58",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1",
-                "squizlabs/php_codesniffer": "^3.2.3"
+                "squizlabs/php_codesniffer": "^3.4.0"
             },
             "require-dev": {
                 "jakub-onderka/php-parallel-lint": "1.0.0",
@@ -4036,7 +4037,7 @@
                 "phpstan/phpstan": "0.9.2",
                 "phpstan/phpstan-phpunit": "0.9.4",
                 "phpstan/phpstan-strict-rules": "0.9",
-                "phpunit/phpunit": "7.2.4"
+                "phpunit/phpunit": "7.5.1"
             },
             "type": "phpcodesniffer-standard",
             "autoload": {
@@ -4049,20 +4050,20 @@
                 "MIT"
             ],
             "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
-            "time": "2018-06-29T20:25:43+00:00"
+            "time": "2019-01-03T13:15:50+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.3.1",
+            "version": "3.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "628a481780561150481a9ec74709092b9759b3ec"
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/628a481780561150481a9ec74709092b9759b3ec",
-                "reference": "628a481780561150481a9ec74709092b9759b3ec",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
                 "shasum": ""
             },
             "require": {
@@ -4095,12 +4096,12 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-07-26T23:47:18+00:00"
+            "time": "2019-04-10T23:49:02+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/src/CompareClasses.php
+++ b/src/CompareClasses.php
@@ -45,12 +45,12 @@ final class CompareClasses implements CompareApi
         ClassReflector $newSourcesWithDependencies
     ) : Changes {
         $definedApiClassNames = array_map(
-            function (ReflectionClass $class) : string {
+            static function (ReflectionClass $class) : string {
                 return $class->getName();
             },
             array_filter(
                 $definedSymbols->getAllClasses(),
-                function (ReflectionClass $class) : bool {
+                static function (ReflectionClass $class) : bool {
                     return ! $class->isAnonymous();
                 }
             )

--- a/src/DetectChanges/BCBreak/ClassBased/ConstantRemoved.php
+++ b/src/DetectChanges/BCBreak/ClassBased/ConstantRemoved.php
@@ -23,7 +23,7 @@ final class ConstantRemoved implements ClassBased
             $this->accessibleConstants($toClass)
         );
 
-        return Changes::fromList(...array_values(array_map(function (ReflectionClassConstant $constant) use ($fromClass) : Change {
+        return Changes::fromList(...array_values(array_map(static function (ReflectionClassConstant $constant) use ($fromClass) : Change {
             return Change::removed(
                 sprintf('Constant %s::%s was removed', $fromClass->getName(), $constant->getName()),
                 true
@@ -34,7 +34,7 @@ final class ConstantRemoved implements ClassBased
     /** @return ReflectionClassConstant[] */
     private function accessibleConstants(ReflectionClass $class) : array
     {
-        return array_filter($class->getReflectionConstants(), function (ReflectionClassConstant $constant) : bool {
+        return array_filter($class->getReflectionConstants(), static function (ReflectionClassConstant $constant) : bool {
             return $constant->isPublic() || $constant->isProtected();
         });
     }

--- a/src/DetectChanges/BCBreak/ClassBased/MethodChanged.php
+++ b/src/DetectChanges/BCBreak/ClassBased/MethodChanged.php
@@ -49,7 +49,7 @@ final class MethodChanged implements ClassBased
         $methods = $class->getMethods();
 
         return array_combine(
-            array_map(function (ReflectionMethod $method) : string {
+            array_map(static function (ReflectionMethod $method) : string {
                 return strtolower($method->getName());
             }, $methods),
             $methods

--- a/src/DetectChanges/BCBreak/ClassBased/MethodRemoved.php
+++ b/src/DetectChanges/BCBreak/ClassBased/MethodRemoved.php
@@ -46,12 +46,12 @@ final class MethodRemoved implements ClassBased
     /** @return ReflectionMethod[] */
     private function accessibleMethods(ReflectionClass $class) : array
     {
-        $methods = array_filter($class->getMethods(), function (ReflectionMethod $method) : bool {
+        $methods = array_filter($class->getMethods(), static function (ReflectionMethod $method) : bool {
             return $method->isPublic() || $method->isProtected();
         });
 
         return array_combine(
-            array_map(function (ReflectionMethod $method) : string {
+            array_map(static function (ReflectionMethod $method) : string {
                 return $method->getName();
             }, $methods),
             $methods

--- a/src/DetectChanges/BCBreak/ClassBased/PropertyRemoved.php
+++ b/src/DetectChanges/BCBreak/ClassBased/PropertyRemoved.php
@@ -45,7 +45,7 @@ final class PropertyRemoved implements ClassBased
     /** @return ReflectionProperty[] */
     private function accessibleProperties(ReflectionClass $class) : array
     {
-        return array_filter($class->getProperties(), function (ReflectionProperty $property) : bool {
+        return array_filter($class->getProperties(), static function (ReflectionProperty $property) : bool {
             return $property->isPublic() || $property->isProtected();
         });
     }

--- a/src/DetectChanges/BCBreak/FunctionBased/ParameterDefaultValueChanged.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/ParameterDefaultValueChanged.php
@@ -69,13 +69,13 @@ final class ParameterDefaultValueChanged implements FunctionBased
     {
         $optionalParameters = array_values(array_filter(
             $function->getParameters(),
-            function (ReflectionParameter $parameter) : bool {
+            static function (ReflectionParameter $parameter) : bool {
                 return $parameter->isDefaultValueAvailable();
             }
         ));
 
         return array_combine(
-            array_map(function (ReflectionParameter $parameter) : int {
+            array_map(static function (ReflectionParameter $parameter) : int {
                 return $parameter->getPosition();
             }, $optionalParameters),
             $optionalParameters

--- a/src/DetectChanges/BCBreak/InterfaceBased/MethodAdded.php
+++ b/src/DetectChanges/BCBreak/InterfaceBased/MethodAdded.php
@@ -27,7 +27,7 @@ final class MethodAdded implements InterfaceBased
             return Changes::empty();
         }
 
-        return Changes::fromList(...array_values(array_map(function (ReflectionMethod $method) use (
+        return Changes::fromList(...array_values(array_map(static function (ReflectionMethod $method) use (
             $fromInterface
         ) : Change {
             return Change::added(
@@ -47,7 +47,7 @@ final class MethodAdded implements InterfaceBased
         $methods = $interface->getMethods();
 
         return array_combine(
-            array_map(function (ReflectionMethod $method) : string {
+            array_map(static function (ReflectionMethod $method) : string {
                 return strtolower($method->getName());
             }, $methods),
             $methods

--- a/src/DetectChanges/Variance/TypeIsCovariant.php
+++ b/src/DetectChanges/Variance/TypeIsCovariant.php
@@ -6,6 +6,7 @@ namespace Roave\BackwardCompatibility\DetectChanges\Variance;
 
 use Roave\BackwardCompatibility\Support\ArrayHelpers;
 use Roave\BetterReflection\Reflection\ReflectionType;
+use Traversable;
 use function strtolower;
 
 /**
@@ -57,7 +58,7 @@ final class TypeIsCovariant
         }
 
         if (strtolower($typeAsString) === 'iterable' && ! $comparedType->isBuiltin()) {
-            if ($comparedType->targetReflectionClass()->implementsInterface(\Traversable::class)) {
+            if ($comparedType->targetReflectionClass()->implementsInterface(Traversable::class)) {
                 // `iterable` can be restricted via any `Iterator` implementation
                 return true;
             }

--- a/src/Factory/DirectoryReflectorFactory.php
+++ b/src/Factory/DirectoryReflectorFactory.php
@@ -14,11 +14,11 @@ use Roave\BetterReflection\SourceLocator\Type\MemoizingSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\SourceLocator;
 
 /**
- * @codeCoverageIgnore
- *
  * @deprecated this class builds a simplistic reflector with a DirectoriesSourceLocator around a given
  *             path: that is no longer the preferred approach.
  *             Please use {@see \Roave\BackwardCompatibilityCheck\Factory\ComposerInstallationReflectorFactory} instead.
+ *
+ * @codeCoverageIgnore
  */
 final class DirectoryReflectorFactory
 {

--- a/src/Formatter/MarkdownPipedToSymfonyConsoleFormatter.php
+++ b/src/Formatter/MarkdownPipedToSymfonyConsoleFormatter.php
@@ -31,21 +31,21 @@ final class MarkdownPipedToSymfonyConsoleFormatter implements OutputFormatter
         $this->output->writeln(
             "# Added\n"
             . implode('', $this->convertFilteredChangesToMarkdownBulletList(
-                function (Change $change) : bool {
+                static function (Change $change) : bool {
                     return $change->isAdded();
                 },
                 ...$arrayOfChanges
             ))
             . "\n# Changed\n"
             . implode('', $this->convertFilteredChangesToMarkdownBulletList(
-                function (Change $change) : bool {
+                static function (Change $change) : bool {
                     return $change->isChanged();
                 },
                 ...$arrayOfChanges
             ))
             . "\n# Removed\n"
             . implode('', $this->convertFilteredChangesToMarkdownBulletList(
-                function (Change $change) : bool {
+                static function (Change $change) : bool {
                     return $change->isRemoved();
                 },
                 ...$arrayOfChanges
@@ -57,7 +57,7 @@ final class MarkdownPipedToSymfonyConsoleFormatter implements OutputFormatter
     private function convertFilteredChangesToMarkdownBulletList(callable $filterFunction, Change ...$changes) : array
     {
         return array_map(
-            function (Change $change) : string {
+            static function (Change $change) : string {
                 return ' - ' . str_replace(['ADDED: ', 'CHANGED: ', 'REMOVED: '], '', trim($change->__toString())) . "\n";
             },
             array_filter($changes, $filterFunction)

--- a/src/Git/GetVersionCollectionFromGitRepository.php
+++ b/src/Git/GetVersionCollectionFromGitRepository.php
@@ -19,6 +19,7 @@ final class GetVersionCollectionFromGitRepository implements GetVersionCollectio
 {
     /**
      * {@inheritDoc}
+     *
      * @throws ProcessFailedException
      * @throws LogicException
      * @throws RuntimeException
@@ -31,7 +32,7 @@ final class GetVersionCollectionFromGitRepository implements GetVersionCollectio
             ->getOutput();
 
         return new VersionsCollection(...array_filter(
-            array_map(function (string $maybeVersion) : ?Version {
+            array_map(static function (string $maybeVersion) : ?Version {
                 try {
                     return Version::fromString($maybeVersion);
                 } catch (InvalidVersionStringException $e) {

--- a/src/Git/GitCheckoutRevisionToTemporaryPath.php
+++ b/src/Git/GitCheckoutRevisionToTemporaryPath.php
@@ -23,6 +23,7 @@ final class GitCheckoutRevisionToTemporaryPath implements PerformCheckoutOfRevis
 
     /**
      * {@inheritDoc}
+     *
      * @throws ProcessRuntimeException
      */
     public function checkout(CheckedOutRepository $sourceRepository, Revision $revision) : CheckedOutRepository
@@ -37,6 +38,7 @@ final class GitCheckoutRevisionToTemporaryPath implements PerformCheckoutOfRevis
 
     /**
      * {@inheritDoc}
+     *
      * @throws ProcessRuntimeException
      */
     public function remove(CheckedOutRepository $checkedOutRepository) : void

--- a/src/Git/GitParseRevision.php
+++ b/src/Git/GitParseRevision.php
@@ -11,6 +11,7 @@ final class GitParseRevision implements ParseRevision
 {
     /**
      * {@inheritDoc}
+     *
      * @throws RuntimeException
      */
     public function fromStringForRepository(string $something, CheckedOutRepository $repository) : Revision

--- a/src/Git/PickLastMinorVersionFromCollection.php
+++ b/src/Git/PickLastMinorVersionFromCollection.php
@@ -19,6 +19,7 @@ final class PickLastMinorVersionFromCollection implements PickVersionFromVersion
 {
     /**
      * {@inheritDoc}
+     *
      * @throws LogicException
      * @throws RuntimeException
      */

--- a/src/LocateSources/LocateSourcesViaComposerJson.php
+++ b/src/LocateSources/LocateSourcesViaComposerJson.php
@@ -168,7 +168,7 @@ final class LocateSourcesViaComposerJson implements LocateSources
     /** @return callable (string $path) : string */
     private function prependInstallationPath(string $installationPath) : callable
     {
-        return function (string $path) use ($installationPath) : string {
+        return static function (string $path) use ($installationPath) : string {
             if (strpos($path, './') === 0) {
                 return $installationPath . '/' . substr($path, 2);
             }

--- a/src/Support/ArrayHelpers.php
+++ b/src/Support/ArrayHelpers.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Roave\BackwardCompatibility\Support;
 
 use Assert\Assert;
+use InvalidArgumentException;
 use function in_array;
 
 /**
@@ -18,7 +19,7 @@ final class ArrayHelpers
      *
      * @param string[] $arrayOfStrings
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public static function stringArrayContainsString(string $value, array $arrayOfStrings) : bool
     {

--- a/test/unit/ChangesTest.php
+++ b/test/unit/ChangesTest.php
@@ -48,7 +48,7 @@ final class ChangesTest extends TestCase
     public function testFromIteratorBuffersAllChangesWithoutLoadingThemEagerly() : void
     {
         $producedValues  = 0;
-        $changesProvider = function () use (& $producedValues) {
+        $changesProvider = static function () use (& $producedValues) {
             $producedValues += 1;
 
             yield Change::changed('a', true);

--- a/test/unit/Command/AssertBackwardsCompatibleTest.php
+++ b/test/unit/Command/AssertBackwardsCompatibleTest.php
@@ -274,7 +274,7 @@ final class AssertBackwardsCompatibleTest extends TestCase
 
         $this->output->expects(self::any())
             ->method('writeln')
-            ->willReturnCallback(function (string $output) use ($changeToExpect) : void {
+            ->willReturnCallback(static function (string $output) use ($changeToExpect) : void {
                 self::assertContains($changeToExpect, $output);
             });
     }

--- a/test/unit/DetectChanges/BCBreak/ClassBased/AncestorRemovedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/AncestorRemovedTest.php
@@ -22,9 +22,9 @@ use function iterator_to_array;
 final class AncestorRemovedTest extends TestCase
 {
     /**
-     * @dataProvider classesToBeTested
-     *
      * @param string[] $expectedMessages
+     *
+     * @dataProvider classesToBeTested
      */
     public function testDiffs(
         ReflectionClass $fromClass,
@@ -36,7 +36,7 @@ final class AncestorRemovedTest extends TestCase
 
         self::assertSame(
             $expectedMessages,
-            array_map(function (Change $change) : string {
+            array_map(static function (Change $change) : string {
                 return $change->__toString();
             }, iterator_to_array($changes))
         );
@@ -129,7 +129,7 @@ PHP
         return array_combine(
             array_keys($classes),
             array_map(
-                function (string $className, array $errors) use ($fromReflector, $toReflector) : array {
+                static function (string $className, array $errors) use ($fromReflector, $toReflector) : array {
                     return [
                         $fromReflector->reflect($className),
                         $toReflector->reflect($className),

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameAbstractTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameAbstractTest.php
@@ -22,9 +22,9 @@ use function iterator_to_array;
 final class ClassBecameAbstractTest extends TestCase
 {
     /**
-     * @dataProvider classesToBeTested
-     *
      * @param string[] $expectedMessages
+     *
+     * @dataProvider classesToBeTested
      */
     public function testDiffs(
         ReflectionClass $fromClass,
@@ -36,7 +36,7 @@ final class ClassBecameAbstractTest extends TestCase
 
         self::assertSame(
             $expectedMessages,
-            array_map(function (Change $change) : string {
+            array_map(static function (Change $change) : string {
                 return $change->__toString();
             }, iterator_to_array($changes))
         );
@@ -96,7 +96,7 @@ PHP
         return array_combine(
             array_keys($classes),
             array_map(
-                function (string $className, array $errors) use ($fromReflector, $toReflector) : array {
+                static function (string $className, array $errors) use ($fromReflector, $toReflector) : array {
                     return [
                         $fromReflector->reflect($className),
                         $toReflector->reflect($className),

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameFinalTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameFinalTest.php
@@ -17,9 +17,9 @@ use function iterator_to_array;
 final class ClassBecameFinalTest extends TestCase
 {
     /**
-     * @dataProvider classesToBeTested
-     *
      * @param string[] $expectedMessages
+     *
+     * @dataProvider classesToBeTested
      */
     public function testDiffs(
         ReflectionClass $fromClass,
@@ -31,7 +31,7 @@ final class ClassBecameFinalTest extends TestCase
 
         self::assertSame(
             $expectedMessages,
-            array_map(function (Change $change) : string {
+            array_map(static function (Change $change) : string {
                 return $change->__toString();
             }, iterator_to_array($changes))
         );

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameInterfaceTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameInterfaceTest.php
@@ -19,9 +19,9 @@ use function iterator_to_array;
 final class ClassBecameInterfaceTest extends TestCase
 {
     /**
-     * @dataProvider classesToBeTested
-     *
      * @param string[] $expectedMessages
+     *
+     * @dataProvider classesToBeTested
      */
     public function testDiffs(
         ReflectionClass $fromClass,
@@ -33,7 +33,7 @@ final class ClassBecameInterfaceTest extends TestCase
 
         self::assertSame(
             $expectedMessages,
-            array_map(function (Change $change) : string {
+            array_map(static function (Change $change) : string {
                 return $change->__toString();
             }, iterator_to_array($changes))
         );
@@ -102,7 +102,7 @@ PHP
         return array_combine(
             array_keys($classes),
             array_map(
-                function (string $className, array $errors) use ($fromReflector, $toReflector) : array {
+                static function (string $className, array $errors) use ($fromReflector, $toReflector) : array {
                     return [
                         $fromReflector->reflect($className),
                         $toReflector->reflect($className),

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameTraitTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameTraitTest.php
@@ -22,9 +22,9 @@ use function iterator_to_array;
 final class ClassBecameTraitTest extends TestCase
 {
     /**
-     * @dataProvider classesToBeTested
-     *
      * @param string[] $expectedMessages
+     *
+     * @dataProvider classesToBeTested
      */
     public function testDiffs(
         ReflectionClass $fromClass,
@@ -36,7 +36,7 @@ final class ClassBecameTraitTest extends TestCase
 
         self::assertSame(
             $expectedMessages,
-            array_map(function (Change $change) : string {
+            array_map(static function (Change $change) : string {
                 return $change->__toString();
             }, iterator_to_array($changes))
         );
@@ -105,7 +105,7 @@ PHP
         return array_combine(
             array_keys($classes),
             array_map(
-                function (string $className, array $errors) use ($fromReflector, $toReflector) : array {
+                static function (string $className, array $errors) use ($fromReflector, $toReflector) : array {
                     return [
                         $fromReflector->reflect($className),
                         $toReflector->reflect($className),

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ConstantChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ConstantChangedTest.php
@@ -61,7 +61,7 @@ PHP
         $comparator
             ->expects(self::exactly(2))
             ->method('__invoke')
-            ->willReturnCallback(function (ReflectionClassConstant $from, ReflectionClassConstant $to) : Changes {
+            ->willReturnCallback(static function (ReflectionClassConstant $from, ReflectionClassConstant $to) : Changes {
                 $propertyName = $from->getName();
 
                 self::assertSame($propertyName, $to->getName());

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ConstantRemovedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ConstantRemovedTest.php
@@ -17,9 +17,9 @@ use function iterator_to_array;
 final class ConstantRemovedTest extends TestCase
 {
     /**
-     * @dataProvider classesToBeTested
-     *
      * @param string[] $expectedMessages
+     *
+     * @dataProvider classesToBeTested
      */
     public function testDiffs(
         ReflectionClass $fromClass,
@@ -31,7 +31,7 @@ final class ConstantRemovedTest extends TestCase
 
         self::assertSame(
             $expectedMessages,
-            array_map(function (Change $change) : string {
+            array_map(static function (Change $change) : string {
                 return $change->__toString();
             }, iterator_to_array($changes))
         );

--- a/test/unit/DetectChanges/BCBreak/ClassBased/MethodChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/MethodChangedTest.php
@@ -62,7 +62,7 @@ PHP
         $comparator
             ->expects(self::exactly(3))
             ->method('__invoke')
-            ->willReturnCallback(function (ReflectionMethod $from, ReflectionMethod $to) : Changes {
+            ->willReturnCallback(static function (ReflectionMethod $from, ReflectionMethod $to) : Changes {
                 $methodName = $from->getName();
 
                 self::assertSame(strtolower($methodName), strtolower($to->getName()));

--- a/test/unit/DetectChanges/BCBreak/ClassBased/MethodRemovedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/MethodRemovedTest.php
@@ -17,9 +17,9 @@ use function iterator_to_array;
 final class MethodRemovedTest extends TestCase
 {
     /**
-     * @dataProvider classesToBeTested
-     *
      * @param string[] $expectedMessages
+     *
+     * @dataProvider classesToBeTested
      */
     public function testDiffs(
         ReflectionClass $fromClass,
@@ -31,7 +31,7 @@ final class MethodRemovedTest extends TestCase
 
         self::assertSame(
             $expectedMessages,
-            array_map(function (Change $change) : string {
+            array_map(static function (Change $change) : string {
                 return $change->__toString();
             }, iterator_to_array($changes))
         );

--- a/test/unit/DetectChanges/BCBreak/ClassBased/PropertyChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/PropertyChangedTest.php
@@ -61,7 +61,7 @@ PHP
         $comparator
             ->expects(self::exactly(2))
             ->method('__invoke')
-            ->willReturnCallback(function (ReflectionProperty $from, ReflectionProperty $to) : Changes {
+            ->willReturnCallback(static function (ReflectionProperty $from, ReflectionProperty $to) : Changes {
                 $propertyName = $from->getName();
 
                 self::assertSame($propertyName, $to->getName());

--- a/test/unit/DetectChanges/BCBreak/ClassBased/PropertyRemovedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/PropertyRemovedTest.php
@@ -17,9 +17,9 @@ use function iterator_to_array;
 final class PropertyRemovedTest extends TestCase
 {
     /**
-     * @dataProvider classesToBeTested
-     *
      * @param string[] $expectedMessages
+     *
+     * @dataProvider classesToBeTested
      */
     public function testDiffs(
         ReflectionClass $fromClass,
@@ -31,7 +31,7 @@ final class PropertyRemovedTest extends TestCase
 
         self::assertSame(
             $expectedMessages,
-            array_map(function (Change $change) : string {
+            array_map(static function (Change $change) : string {
                 return $change->__toString();
             }, iterator_to_array($changes))
         );

--- a/test/unit/DetectChanges/BCBreak/ClassConstantBased/ClassConstantValueChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassConstantBased/ClassConstantValueChangedTest.php
@@ -23,9 +23,9 @@ use function iterator_to_array;
 final class ClassConstantValueChangedTest extends TestCase
 {
     /**
-     * @dataProvider propertiesToBeTested
-     *
      * @param string[] $expectedMessages
+     *
+     * @dataProvider propertiesToBeTested
      */
     public function testDiffs(
         ReflectionClassConstant $fromConstant,
@@ -37,7 +37,7 @@ final class ClassConstantValueChangedTest extends TestCase
 
         self::assertSame(
             $expectedMessages,
-            array_map(function (Change $change) : string {
+            array_map(static function (Change $change) : string {
                 return $change->__toString();
             }, iterator_to_array($changes))
         );
@@ -121,7 +121,7 @@ PHP
         return array_combine(
             array_keys($properties),
             array_map(
-                function (string $constant, array $errorMessages) use ($fromClass, $toClass) : array {
+                static function (string $constant, array $errorMessages) use ($fromClass, $toClass) : array {
                     return [
                         $fromClass->getReflectionConstant($constant),
                         $toClass->getReflectionConstant($constant),

--- a/test/unit/DetectChanges/BCBreak/InterfaceBased/AncestorRemovedTest.php
+++ b/test/unit/DetectChanges/BCBreak/InterfaceBased/AncestorRemovedTest.php
@@ -22,9 +22,9 @@ use function iterator_to_array;
 final class AncestorRemovedTest extends TestCase
 {
     /**
-     * @dataProvider interfacesToBeTested
-     *
      * @param string[] $expectedMessages
+     *
+     * @dataProvider interfacesToBeTested
      */
     public function testDiffs(
         ReflectionClass $fromInterface,
@@ -36,7 +36,7 @@ final class AncestorRemovedTest extends TestCase
 
         self::assertSame(
             $expectedMessages,
-            array_map(function (Change $change) : string {
+            array_map(static function (Change $change) : string {
                 return $change->__toString();
             }, iterator_to_array($changes))
         );
@@ -95,7 +95,7 @@ PHP
         return array_combine(
             array_keys($interfaces),
             array_map(
-                function (string $interfaceName, array $errors) use ($fromReflector, $toReflector) : array {
+                static function (string $interfaceName, array $errors) use ($fromReflector, $toReflector) : array {
                     return [
                         $fromReflector->reflect($interfaceName),
                         $toReflector->reflect($interfaceName),

--- a/test/unit/DetectChanges/BCBreak/InterfaceBased/InterfaceBecameClassTest.php
+++ b/test/unit/DetectChanges/BCBreak/InterfaceBased/InterfaceBecameClassTest.php
@@ -19,9 +19,9 @@ use function iterator_to_array;
 final class InterfaceBecameClassTest extends TestCase
 {
     /**
-     * @dataProvider classesToBeTested
-     *
      * @param string[] $expectedMessages
+     *
+     * @dataProvider classesToBeTested
      */
     public function testDiffs(
         ReflectionClass $fromClass,
@@ -33,7 +33,7 @@ final class InterfaceBecameClassTest extends TestCase
 
         self::assertSame(
             $expectedMessages,
-            array_map(function (Change $change) : string {
+            array_map(static function (Change $change) : string {
                 return $change->__toString();
             }, iterator_to_array($changes))
         );
@@ -102,7 +102,7 @@ PHP
         return array_combine(
             array_keys($classes),
             array_map(
-                function (string $className, array $errors) use ($fromReflector, $toReflector) : array {
+                static function (string $className, array $errors) use ($fromReflector, $toReflector) : array {
                     return [
                         $fromReflector->reflect($className),
                         $toReflector->reflect($className),

--- a/test/unit/DetectChanges/BCBreak/InterfaceBased/InterfaceBecameTraitTest.php
+++ b/test/unit/DetectChanges/BCBreak/InterfaceBased/InterfaceBecameTraitTest.php
@@ -19,9 +19,9 @@ use function iterator_to_array;
 final class InterfaceBecameTraitTest extends TestCase
 {
     /**
-     * @dataProvider classesToBeTested
-     *
      * @param string[] $expectedMessages
+     *
+     * @dataProvider classesToBeTested
      */
     public function testDiffs(
         ReflectionClass $fromClass,
@@ -33,7 +33,7 @@ final class InterfaceBecameTraitTest extends TestCase
 
         self::assertSame(
             $expectedMessages,
-            array_map(function (Change $change) : string {
+            array_map(static function (Change $change) : string {
                 return $change->__toString();
             }, iterator_to_array($changes))
         );
@@ -102,7 +102,7 @@ PHP
         return array_combine(
             array_keys($classes),
             array_map(
-                function (string $className, array $errors) use ($fromReflector, $toReflector) : array {
+                static function (string $className, array $errors) use ($fromReflector, $toReflector) : array {
                     return [
                         $fromReflector->reflect($className),
                         $toReflector->reflect($className),

--- a/test/unit/DetectChanges/BCBreak/InterfaceBased/MethodAddedTest.php
+++ b/test/unit/DetectChanges/BCBreak/InterfaceBased/MethodAddedTest.php
@@ -19,9 +19,9 @@ use function iterator_to_array;
 final class MethodAddedTest extends TestCase
 {
     /**
-     * @dataProvider interfacesToBeTested
-     *
      * @param string[] $expectedMessages
+     *
+     * @dataProvider interfacesToBeTested
      */
     public function testDiffs(
         ReflectionClass $fromInterface,
@@ -33,7 +33,7 @@ final class MethodAddedTest extends TestCase
 
         self::assertSame(
             $expectedMessages,
-            array_map(function (Change $change) : string {
+            array_map(static function (Change $change) : string {
                 return $change->__toString();
             }, iterator_to_array($changes))
         );
@@ -106,7 +106,7 @@ PHP
         return array_combine(
             array_keys($properties),
             array_map(
-                function (string $className, array $errorMessages) use ($fromClassReflector, $toClassReflector
+                static function (string $className, array $errorMessages) use ($fromClassReflector, $toClassReflector
                 ) : array {
                     return [
                         $fromClassReflector->reflect($className),

--- a/test/unit/DetectChanges/BCBreak/MethodBased/MethodBecameFinalTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/MethodBecameFinalTest.php
@@ -23,9 +23,9 @@ use function iterator_to_array;
 final class MethodBecameFinalTest extends TestCase
 {
     /**
-     * @dataProvider propertiesToBeTested
-     *
      * @param string[] $expectedMessages
+     *
+     * @dataProvider propertiesToBeTested
      */
     public function testDiffs(
         ReflectionMethod $fromMethod,
@@ -37,7 +37,7 @@ final class MethodBecameFinalTest extends TestCase
 
         self::assertSame(
             $expectedMessages,
-            array_map(function (Change $change) : string {
+            array_map(static function (Change $change) : string {
                 return $change->__toString();
             }, iterator_to_array($changes))
         );
@@ -123,7 +123,7 @@ PHP
         return array_combine(
             array_keys($properties),
             array_map(
-                function (string $methodName, array $errorMessages) use ($fromClass, $toClass) : array {
+                static function (string $methodName, array $errorMessages) use ($fromClass, $toClass) : array {
                     return [
                         $fromClass->getMethod($methodName),
                         $toClass->getMethod($methodName),

--- a/test/unit/DetectChanges/BCBreak/MethodBased/MethodConcretenessChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/MethodConcretenessChangedTest.php
@@ -23,9 +23,9 @@ use function iterator_to_array;
 final class MethodConcretenessChangedTest extends TestCase
 {
     /**
-     * @dataProvider propertiesToBeTested
-     *
      * @param string[] $expectedMessages
+     *
+     * @dataProvider propertiesToBeTested
      */
     public function testDiffs(
         ReflectionMethod $fromMethod,
@@ -37,7 +37,7 @@ final class MethodConcretenessChangedTest extends TestCase
 
         self::assertSame(
             $expectedMessages,
-            array_map(function (Change $change) : string {
+            array_map(static function (Change $change) : string {
                 return $change->__toString();
             }, iterator_to_array($changes))
         );
@@ -123,7 +123,7 @@ PHP
         return array_combine(
             array_keys($properties),
             array_map(
-                function (string $methodName, array $errorMessages) use ($fromClass, $toClass) : array {
+                static function (string $methodName, array $errorMessages) use ($fromClass, $toClass) : array {
                     return [
                         $fromClass->getMethod($methodName),
                         $toClass->getMethod($methodName),

--- a/test/unit/DetectChanges/BCBreak/MethodBased/MethodScopeChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/MethodScopeChangedTest.php
@@ -23,9 +23,9 @@ use function iterator_to_array;
 final class MethodScopeChangedTest extends TestCase
 {
     /**
-     * @dataProvider propertiesToBeTested
-     *
      * @param string[] $expectedMessages
+     *
+     * @dataProvider propertiesToBeTested
      */
     public function testDiffs(
         ReflectionMethod $fromMethod,
@@ -37,7 +37,7 @@ final class MethodScopeChangedTest extends TestCase
 
         self::assertSame(
             $expectedMessages,
-            array_map(function (Change $change) : string {
+            array_map(static function (Change $change) : string {
                 return $change->__toString();
             }, iterator_to_array($changes))
         );
@@ -123,7 +123,7 @@ PHP
         return array_combine(
             array_keys($properties),
             array_map(
-                function (string $methodName, array $errorMessages) use ($fromClass, $toClass) : array {
+                static function (string $methodName, array $errorMessages) use ($fromClass, $toClass) : array {
                     return [
                         $fromClass->getMethod($methodName),
                         $toClass->getMethod($methodName),

--- a/test/unit/DetectChanges/BCBreak/MethodBased/MethodVisibilityReducedTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/MethodVisibilityReducedTest.php
@@ -22,9 +22,9 @@ use function iterator_to_array;
 final class MethodVisibilityReducedTest extends TestCase
 {
     /**
-     * @dataProvider propertiesToBeTested
-     *
      * @param string[] $expectedMessages
+     *
+     * @dataProvider propertiesToBeTested
      */
     public function testDiffs(
         ReflectionMethod $fromMethod,
@@ -36,7 +36,7 @@ final class MethodVisibilityReducedTest extends TestCase
 
         self::assertSame(
             $expectedMessages,
-            array_map(function (Change $change) : string {
+            array_map(static function (Change $change) : string {
                 return $change->__toString();
             }, iterator_to_array($changes))
         );
@@ -108,7 +108,7 @@ PHP
         return array_combine(
             array_keys($properties),
             array_map(
-                function (string $method, array $errorMessages) use ($fromClass, $toClass) : array {
+                static function (string $method, array $errorMessages) use ($fromClass, $toClass) : array {
                     return [
                         $fromClass->getMethod($method),
                         $toClass->getMethod($method),

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyDefaultValueChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyDefaultValueChangedTest.php
@@ -22,9 +22,9 @@ use function iterator_to_array;
 final class PropertyDefaultValueChangedTest extends TestCase
 {
     /**
-     * @dataProvider propertiesToBeTested
-     *
      * @param string[] $expectedMessages
+     *
+     * @dataProvider propertiesToBeTested
      */
     public function testDiffs(
         ReflectionProperty $fromFunction,
@@ -36,7 +36,7 @@ final class PropertyDefaultValueChangedTest extends TestCase
 
         self::assertSame(
             $expectedMessages,
-            array_map(function (Change $change) : string {
+            array_map(static function (Change $change) : string {
                 return $change->__toString();
             }, iterator_to_array($changes))
         );
@@ -138,7 +138,7 @@ PHP
         return array_combine(
             array_keys($properties),
             array_map(
-                function (string $property, array $errorMessages) use ($fromClass, $toClass) : array {
+                static function (string $property, array $errorMessages) use ($fromClass, $toClass) : array {
                     return [
                         $fromClass->getProperty($property),
                         $toClass->getProperty($property),

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyDocumentedTypeChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyDocumentedTypeChangedTest.php
@@ -22,9 +22,9 @@ use function iterator_to_array;
 final class PropertyDocumentedTypeChangedTest extends TestCase
 {
     /**
-     * @dataProvider propertiesToBeTested
-     *
      * @param string[] $expectedMessages
+     *
+     * @dataProvider propertiesToBeTested
      */
     public function testDiffs(
         ReflectionProperty $fromProperty,
@@ -36,7 +36,7 @@ final class PropertyDocumentedTypeChangedTest extends TestCase
 
         self::assertSame(
             $expectedMessages,
-            array_map(function (Change $change) : string {
+            array_map(static function (Change $change) : string {
                 return $change->__toString();
             }, iterator_to_array($changes))
         );
@@ -175,7 +175,7 @@ PHP
         return array_combine(
             array_keys($properties),
             array_map(
-                function (string $property, array $errorMessages) use ($fromClass, $toClass) : array {
+                static function (string $property, array $errorMessages) use ($fromClass, $toClass) : array {
                     return [
                         $fromClass->getProperty($property),
                         $toClass->getProperty($property),

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyScopeChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyScopeChangedTest.php
@@ -22,9 +22,9 @@ use function iterator_to_array;
 final class PropertyScopeChangedTest extends TestCase
 {
     /**
-     * @dataProvider propertiesToBeTested
-     *
      * @param string[] $expectedMessages
+     *
+     * @dataProvider propertiesToBeTested
      */
     public function testDiffs(
         ReflectionProperty $fromFunction,
@@ -36,7 +36,7 @@ final class PropertyScopeChangedTest extends TestCase
 
         self::assertSame(
             $expectedMessages,
-            array_map(function (Change $change) : string {
+            array_map(static function (Change $change) : string {
                 return $change->__toString();
             }, iterator_to_array($changes))
         );
@@ -122,7 +122,7 @@ PHP
         return array_combine(
             array_keys($properties),
             array_map(
-                function (string $property, array $errorMessages) use ($fromClass, $toClass) : array {
+                static function (string $property, array $errorMessages) use ($fromClass, $toClass) : array {
                     return [
                         $fromClass->getProperty($property),
                         $toClass->getProperty($property),

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyVisibilityReducedTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyVisibilityReducedTest.php
@@ -22,9 +22,9 @@ use function iterator_to_array;
 final class PropertyVisibilityReducedTest extends TestCase
 {
     /**
-     * @dataProvider propertiesToBeTested
-     *
      * @param string[] $expectedMessages
+     *
+     * @dataProvider propertiesToBeTested
      */
     public function testDiffs(
         ReflectionProperty $fromProperty,
@@ -36,7 +36,7 @@ final class PropertyVisibilityReducedTest extends TestCase
 
         self::assertSame(
             $expectedMessages,
-            array_map(function (Change $change) : string {
+            array_map(static function (Change $change) : string {
                 return $change->__toString();
             }, iterator_to_array($changes))
         );
@@ -108,7 +108,7 @@ PHP
         return array_combine(
             array_keys($properties),
             array_map(
-                function (string $property, array $errorMessages) use ($fromClass, $toClass) : array {
+                static function (string $property, array $errorMessages) use ($fromClass, $toClass) : array {
                     return [
                         $fromClass->getProperty($property),
                         $toClass->getProperty($property),

--- a/test/unit/DetectChanges/BCBreak/TraitBased/TraitBecameClassTest.php
+++ b/test/unit/DetectChanges/BCBreak/TraitBased/TraitBecameClassTest.php
@@ -22,9 +22,9 @@ use function iterator_to_array;
 final class TraitBecameClassTest extends TestCase
 {
     /**
-     * @dataProvider classesToBeTested
-     *
      * @param string[] $expectedMessages
+     *
+     * @dataProvider classesToBeTested
      */
     public function testDiffs(
         ReflectionClass $fromClass,
@@ -36,7 +36,7 @@ final class TraitBecameClassTest extends TestCase
 
         self::assertSame(
             $expectedMessages,
-            array_map(function (Change $change) : string {
+            array_map(static function (Change $change) : string {
                 return $change->__toString();
             }, iterator_to_array($changes))
         );
@@ -90,7 +90,7 @@ PHP
         return array_combine(
             array_keys($classes),
             array_map(
-                function (string $className, array $errors) use ($fromReflector, $toReflector) : array {
+                static function (string $className, array $errors) use ($fromReflector, $toReflector) : array {
                     return [
                         $fromReflector->reflect($className),
                         $toReflector->reflect($className),

--- a/test/unit/DetectChanges/BCBreak/TraitBased/TraitBecameInterfaceTest.php
+++ b/test/unit/DetectChanges/BCBreak/TraitBased/TraitBecameInterfaceTest.php
@@ -22,9 +22,9 @@ use function iterator_to_array;
 final class TraitBecameInterfaceTest extends TestCase
 {
     /**
-     * @dataProvider classesToBeTested
-     *
      * @param string[] $expectedMessages
+     *
+     * @dataProvider classesToBeTested
      */
     public function testDiffs(
         ReflectionClass $fromClass,
@@ -36,7 +36,7 @@ final class TraitBecameInterfaceTest extends TestCase
 
         self::assertSame(
             $expectedMessages,
-            array_map(function (Change $change) : string {
+            array_map(static function (Change $change) : string {
                 return $change->__toString();
             }, iterator_to_array($changes))
         );
@@ -90,7 +90,7 @@ PHP
         return array_combine(
             array_keys($classes),
             array_map(
-                function (string $className, array $errors) use ($fromReflector, $toReflector) : array {
+                static function (string $className, array $errors) use ($fromReflector, $toReflector) : array {
                     return [
                         $fromReflector->reflect($className),
                         $toReflector->reflect($className),

--- a/test/unit/DetectChanges/Variance/TypeIsContravariantTest.php
+++ b/test/unit/DetectChanges/Variance/TypeIsContravariantTest.php
@@ -224,7 +224,7 @@ PHP
         return array_merge(
             [[null]],
             array_merge(...array_map(
-                function (string $type) use ($reflector) : array {
+                static function (string $type) use ($reflector) : array {
                     return [
                         [ReflectionType::createFromTypeAndReflector($type, false, $reflector)],
                         [ReflectionType::createFromTypeAndReflector($type, true, $reflector)],

--- a/test/unit/DetectChanges/Variance/TypeIsCovariantTest.php
+++ b/test/unit/DetectChanges/Variance/TypeIsCovariantTest.php
@@ -235,7 +235,7 @@ PHP
         return array_merge(
             [[null]],
             array_merge(...array_map(
-                function (string $type) use ($reflector) : array {
+                static function (string $type) use ($reflector) : array {
                     return [
                         [ReflectionType::createFromTypeAndReflector($type, false, $reflector)],
                         [ReflectionType::createFromTypeAndReflector($type, true, $reflector)],

--- a/test/unit/Formatter/MarkdownPipedToSymfonyConsoleFormatterTest.php
+++ b/test/unit/Formatter/MarkdownPipedToSymfonyConsoleFormatterTest.php
@@ -36,7 +36,7 @@ EOF;
 
         $output->expects(self::any())
             ->method('writeln')
-            ->willReturnCallback(function (string $output) use ($changeToExpect) : void {
+            ->willReturnCallback(static function (string $output) use ($changeToExpect) : void {
                 self::assertContains($changeToExpect, $output);
             });
 

--- a/test/unit/Formatter/ReflectionPropertyNameTest.php
+++ b/test/unit/Formatter/ReflectionPropertyNameTest.php
@@ -63,7 +63,7 @@ PHP
         return array_combine(
             array_keys($properties),
             array_map(
-                function (string $expectedMessage, ReflectionProperty $property) : array {
+                static function (string $expectedMessage, ReflectionProperty $property) : array {
                     return [$property, $expectedMessage];
                 },
                 array_keys($properties),

--- a/test/unit/Formatter/SymfonyConsoleTextFormatterTest.php
+++ b/test/unit/Formatter/SymfonyConsoleTextFormatterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace RoaveTest\BackwardCompatibility\Formatter;
 
 use PHPUnit\Framework\TestCase;
+use ReflectionException;
 use Roave\BackwardCompatibility\Change;
 use Roave\BackwardCompatibility\Changes;
 use Roave\BackwardCompatibility\Formatter\SymfonyConsoleTextFormatter;
@@ -18,7 +19,7 @@ use function uniqid;
 final class SymfonyConsoleTextFormatterTest extends TestCase
 {
     /**
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testWrite() : void
     {

--- a/test/unit/Git/GetVersionCollectionFromGitRepositoryTest.php
+++ b/test/unit/Git/GetVersionCollectionFromGitRepositoryTest.php
@@ -49,7 +49,7 @@ final class GetVersionCollectionFromGitRepositoryTest extends TestCase
     private function getTags() : array
     {
         return array_map(
-            function (Version $version) {
+            static function (Version $version) {
                 return $version->getVersionString();
             },
             iterator_to_array((new GetVersionCollectionFromGitRepository())->fromRepository($this->repoPath))

--- a/test/unit/Git/GitCheckoutRevisionToTemporaryPathTest.php
+++ b/test/unit/Git/GitCheckoutRevisionToTemporaryPathTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Roave\BackwardCompatibility\Git\CheckedOutRepository;
 use Roave\BackwardCompatibility\Git\GitCheckoutRevisionToTemporaryPath;
 use Roave\BackwardCompatibility\Git\Revision;
+use RuntimeException;
 use function realpath;
 
 /**
@@ -47,7 +48,7 @@ final class GitCheckoutRevisionToTemporaryPathTest extends TestCase
 
     public function testExceptionIsThrownWhenTwoPathsCollide() : void
     {
-        $git              = new GitCheckoutRevisionToTemporaryPath(function () : string {
+        $git              = new GitCheckoutRevisionToTemporaryPath(static function () : string {
             return 'foo';
         });
         $sourceRepository = $this->sourceRepository();
@@ -61,7 +62,7 @@ final class GitCheckoutRevisionToTemporaryPathTest extends TestCase
             $second                            = $git->checkout($sourceRepository, $revision);
             $successfullyCheckedOutSecondClone = true;
             $git->remove($second);
-        } catch (\RuntimeException $runtimeException) {
+        } catch (RuntimeException $runtimeException) {
             self::assertStringMatchesFormat(
                 'Tried to check out revision "%s" to directory "%s" which already exists',
                 $runtimeException->getMessage()

--- a/test/unit/Git/PickLastMinorVersionFromCollectionTest.php
+++ b/test/unit/Git/PickLastMinorVersionFromCollectionTest.php
@@ -38,6 +38,7 @@ final class PickLastMinorVersionFromCollectionTest extends TestCase
 
     /**
      * @param string[] $collectionOfVersions
+     *
      * @dataProvider lastStableMinorVersionForCollectionProvider
      */
     public function testForRepository(string $expectedVersion, array $collectionOfVersions) : void
@@ -45,7 +46,7 @@ final class PickLastMinorVersionFromCollectionTest extends TestCase
         self::assertSame(
             $expectedVersion,
             (new PickLastMinorVersionFromCollection())->forVersions(
-                new VersionsCollection(...array_map(function (string $version) : Version {
+                new VersionsCollection(...array_map(static function (string $version) : Version {
                     return Version::fromString($version);
                 }, $collectionOfVersions))
             )->getVersionString()

--- a/test/unit/LocateDependencies/LocateDependenciesViaComposerTest.php
+++ b/test/unit/LocateDependencies/LocateDependenciesViaComposerTest.php
@@ -7,6 +7,7 @@ namespace RoaveTest\BackwardCompatibility\LocateDependencies;
 use Composer\Installer;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 use Roave\BackwardCompatibility\LocateDependencies\LocateDependenciesViaComposer;
 use Roave\BackwardCompatibility\SourceLocator\StaticClassMapSourceLocator;
 use Roave\BetterReflection\BetterReflection;
@@ -116,7 +117,7 @@ final class LocateDependenciesViaComposerTest extends TestCase
 
         self::assertInstanceOf(AggregateSourceLocator::class, $locator);
 
-        $reflectionLocators = new \ReflectionProperty(AggregateSourceLocator::class, 'sourceLocators');
+        $reflectionLocators = new ReflectionProperty(AggregateSourceLocator::class, 'sourceLocators');
 
         $reflectionLocators->setAccessible(true);
 
@@ -167,7 +168,7 @@ final class LocateDependenciesViaComposerTest extends TestCase
 
         self::assertInstanceOf(AggregateSourceLocator::class, $locator);
 
-        $reflectionLocators = new \ReflectionProperty(AggregateSourceLocator::class, 'sourceLocators');
+        $reflectionLocators = new ReflectionProperty(AggregateSourceLocator::class, 'sourceLocators');
 
         $reflectionLocators->setAccessible(true);
 

--- a/test/unit/SourceLocator/StaticClassMapSourceLocatorTest.php
+++ b/test/unit/SourceLocator/StaticClassMapSourceLocatorTest.php
@@ -74,7 +74,7 @@ final class StaticClassMapSourceLocatorTest extends TestCase
             ->astLocator
             ->expects(self::once())
             ->method('findReflection')
-            ->with($this->reflector, self::callback(function (LocatedSource $source) : bool {
+            ->with($this->reflector, self::callback(static function (LocatedSource $source) : bool {
                 self::assertSame(file_get_contents(__FILE__), $source->getSource());
                 self::assertSame(__FILE__, $source->getFileName());
                 self::assertNull($source->getExtensionName());

--- a/test/unit/Support/ArrayHelpersTest.php
+++ b/test/unit/Support/ArrayHelpersTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace RoaveTest\BackwardCompatibility\Support;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Roave\BackwardCompatibility\Support\ArrayHelpers;
 use stdClass;
@@ -14,9 +15,9 @@ use stdClass;
 final class ArrayHelpersTest extends TestCase
 {
     /**
-     * @dataProvider stringArrayContainsStringValidValues
-     *
      * @param string[] $array
+     *
+     * @dataProvider stringArrayContainsStringValidValues
      */
     public function testInclusion(string $value, array $array, bool $expected) : void
     {
@@ -66,13 +67,13 @@ final class ArrayHelpersTest extends TestCase
     }
 
     /**
-     * @dataProvider invalidStringArrays
-     *
      * @param mixed[] $array
+     *
+     * @dataProvider invalidStringArrays
      */
     public function testRejectsArraysWithNonStringValues(array $array) : void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         ArrayHelpers::stringArrayContainsString('', $array);
     }


### PR DESCRIPTION
Unfortunately, to bump `doctrine/cs` to v6, we need to update PHPStan first:

```
Problem 1
    - Installation request for doctrine/coding-standard ^6.0 -> satisfiable by doctrine/coding-standard[6.0.0].
    - doctrine/coding-standard 6.0.0 requires slevomat/coding-standard ^5.0 -> satisfiable by slevomat/coding-standard[5.0.0, 5.0.1, 5.0.2, 5.0.3, 5.0.4].
    - slevomat/coding-standard 5.0.0 requires phpstan/phpdoc-parser ^0.3.1 -> satisfiable by phpstan/phpdoc-parser[0.3.1].
    - slevomat/coding-standard 5.0.1 requires phpstan/phpdoc-parser ^0.3.1 -> satisfiable by phpstan/phpdoc-parser[0.3.1].
    - slevomat/coding-standard 5.0.2 requires phpstan/phpdoc-parser ^0.3.1 -> satisfiable by phpstan/phpdoc-parser[0.3.1].
    - slevomat/coding-standard 5.0.3 requires phpstan/phpdoc-parser ^0.3.1 -> satisfiable by phpstan/phpdoc-parser[0.3.1].
    - slevomat/coding-standard 5.0.4 requires phpstan/phpdoc-parser ^0.3.1 -> satisfiable by phpstan/phpdoc-parser[0.3.1].
    - Conclusion: don't install phpstan/phpdoc-parser 0.3.1
```

Let's update this first :)