### PR TITLE
Support skipping BC checks for `@internal` symbols

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 sudo: false
 
 php:
-  - 7.2
   - 7.3
   - 7.4snapshot
   - nightly

--- a/bin/roave-backward-compatibility-check.php
+++ b/bin/roave-backward-compatibility-check.php
@@ -79,7 +79,7 @@ use function file_exists;
             $astLocator
         ),
         new CompareClasses(
-            new ClassBased\SkipClassBasedErrors(new ClassBased\ExcludeAnonymousClasses(
+            new ClassBased\SkipClassBasedErrors(new ClassBased\ExcludeAnonymousClasses(new ClassBased\ExcludeInternalClass(
                 new ClassBased\MultipleChecksOnAClass(
                     new ClassBased\SkipClassBasedErrors(new ClassBased\ClassBecameAbstract()),
                     new ClassBased\SkipClassBasedErrors(new ClassBased\ClassBecameInterface()),
@@ -89,6 +89,7 @@ use function file_exists;
                     new ClassBased\SkipClassBasedErrors(new ClassBased\PropertyRemoved()),
                     new ClassBased\SkipClassBasedErrors(new ClassBased\MethodRemoved()),
                     new ClassBased\SkipClassBasedErrors(new ClassBased\AncestorRemoved()),
+                    new ClassBased\SkipClassBasedErrors(new ClassBased\ClassBecameInternal()),
                     new ClassBased\SkipClassBasedErrors(new ClassBased\OpenClassChanged(
                         new ClassBased\MultipleChecksOnAClass(
                             new ClassBased\SkipClassBasedErrors(new ClassBased\ConstantChanged(
@@ -108,9 +109,10 @@ use function file_exists;
                                 )
                             )),
                             new ClassBased\SkipClassBasedErrors(new ClassBased\PropertyChanged(
-                                new PropertyBased\MultipleChecksOnAProperty(
+                                new PropertyBased\SkipPropertyBasedErrors(new PropertyBased\ExcludeInternalProperty(new PropertyBased\MultipleChecksOnAProperty(
                                     new PropertyBased\SkipPropertyBasedErrors(new PropertyBased\OnlyPublicPropertyChanged(
                                         new PropertyBased\MultipleChecksOnAProperty(
+                                            new PropertyBased\SkipPropertyBasedErrors(new PropertyBased\PropertyBecameInternal()),
                                             new PropertyBased\SkipPropertyBasedErrors(new PropertyBased\PropertyDocumentedTypeChanged()),
                                             new PropertyBased\SkipPropertyBasedErrors(new PropertyBased\PropertyDefaultValueChanged()),
                                             new PropertyBased\SkipPropertyBasedErrors(new PropertyBased\PropertyVisibilityReduced()),
@@ -119,16 +121,17 @@ use function file_exists;
                                     )),
                                     new PropertyBased\SkipPropertyBasedErrors(new PropertyBased\OnlyProtectedPropertyChanged(
                                         new PropertyBased\MultipleChecksOnAProperty(
+                                            new PropertyBased\SkipPropertyBasedErrors(new PropertyBased\PropertyBecameInternal()),
                                             new PropertyBased\SkipPropertyBasedErrors(new PropertyBased\PropertyDocumentedTypeChanged()),
                                             new PropertyBased\SkipPropertyBasedErrors(new PropertyBased\PropertyDefaultValueChanged()),
                                             new PropertyBased\SkipPropertyBasedErrors(new PropertyBased\PropertyVisibilityReduced()),
                                             new PropertyBased\SkipPropertyBasedErrors(new PropertyBased\PropertyScopeChanged())
                                         )
                                     ))
-                                )
+                                )))
                             )),
                             new ClassBased\SkipClassBasedErrors(new ClassBased\MethodChanged(
-                                new MethodBased\MultipleChecksOnAMethod(
+                                new MethodBased\SkipMethodBasedErrors(new MethodBased\ExcludeInternalMethod(new MethodBased\MultipleChecksOnAMethod(
                                     new MethodBased\SkipMethodBasedErrors(new MethodBased\OnlyPublicMethodChanged(
                                         new MethodBased\MultipleChecksOnAMethod(
                                             new MethodBased\SkipMethodBasedErrors(new MethodBased\MethodBecameFinal()),
@@ -137,6 +140,7 @@ use function file_exists;
                                             new MethodBased\SkipMethodBasedErrors(new MethodBased\MethodVisibilityReduced()),
                                             new MethodBased\SkipMethodBasedErrors(new MethodBased\MethodFunctionDefinitionChanged(
                                                 new FunctionBased\MultipleChecksOnAFunction(
+                                                    new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\FunctionBecameInternal()),
                                                     new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ParameterByReferenceChanged()),
                                                     new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ReturnTypeByReferenceChanged()),
                                                     new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\RequiredParameterAmountIncreased()),
@@ -157,6 +161,7 @@ use function file_exists;
                                             new MethodBased\SkipMethodBasedErrors(new MethodBased\MethodVisibilityReduced()),
                                             new MethodBased\SkipMethodBasedErrors(new MethodBased\MethodFunctionDefinitionChanged(
                                                 new FunctionBased\MultipleChecksOnAFunction(
+                                                    new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\FunctionBecameInternal()),
                                                     new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ParameterByReferenceChanged()),
                                                     new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ReturnTypeByReferenceChanged()),
                                                     new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\RequiredParameterAmountIncreased()),
@@ -169,7 +174,7 @@ use function file_exists;
                                             ))
                                         )
                                     ))
-                                )
+                                )))
                             ))
                         )
                     )),
@@ -186,6 +191,7 @@ use function file_exists;
                             new ClassBased\SkipClassBasedErrors(new ClassBased\PropertyChanged(
                                 new PropertyBased\SkipPropertyBasedErrors(new PropertyBased\OnlyPublicPropertyChanged(
                                     new PropertyBased\MultipleChecksOnAProperty(
+                                        new PropertyBased\SkipPropertyBasedErrors(new PropertyBased\PropertyBecameInternal()),
                                         new PropertyBased\SkipPropertyBasedErrors(new PropertyBased\PropertyDocumentedTypeChanged()),
                                         new PropertyBased\SkipPropertyBasedErrors(new PropertyBased\PropertyDefaultValueChanged()),
                                         new PropertyBased\SkipPropertyBasedErrors(new PropertyBased\PropertyVisibilityReduced()),
@@ -202,6 +208,7 @@ use function file_exists;
                                         new MethodBased\SkipMethodBasedErrors(new MethodBased\MethodVisibilityReduced()),
                                         new MethodBased\SkipMethodBasedErrors(new MethodBased\MethodFunctionDefinitionChanged(
                                             new FunctionBased\MultipleChecksOnAFunction(
+                                                new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\FunctionBecameInternal()),
                                                 new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ParameterByReferenceChanged()),
                                                 new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ReturnTypeByReferenceChanged()),
                                                 new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\RequiredParameterAmountIncreased()),
@@ -216,14 +223,15 @@ use function file_exists;
                         )
                     ))
                 )
-            )),
-            new InterfaceBased\MultipleChecksOnAnInterface(
+            ))),
+            new InterfaceBased\SkipInterfaceBasedErrors(new InterfaceBased\ExcludeInternalInterface(new InterfaceBased\MultipleChecksOnAnInterface(
                 new InterfaceBased\SkipInterfaceBasedErrors(new InterfaceBased\InterfaceBecameClass()),
                 new InterfaceBased\SkipInterfaceBasedErrors(new InterfaceBased\InterfaceBecameTrait()),
                 new InterfaceBased\SkipInterfaceBasedErrors(new InterfaceBased\AncestorRemoved()),
                 new InterfaceBased\SkipInterfaceBasedErrors(new InterfaceBased\MethodAdded()),
                 new InterfaceBased\SkipInterfaceBasedErrors(new InterfaceBased\UseClassBasedChecksOnAnInterface(
                     new ClassBased\MultipleChecksOnAClass(
+                        new ClassBased\SkipClassBasedErrors(new ClassBased\ClassBecameInternal()),
                         new ClassBased\SkipClassBasedErrors(new ClassBased\ConstantRemoved()),
                         new ClassBased\SkipClassBasedErrors(new ClassBased\MethodRemoved()),
                         new ClassBased\SkipClassBasedErrors(new ClassBased\ConstantChanged(
@@ -234,6 +242,7 @@ use function file_exists;
                                 new MethodBased\SkipMethodBasedErrors(new MethodBased\MethodScopeChanged()),
                                 new MethodBased\SkipMethodBasedErrors(new MethodBased\MethodFunctionDefinitionChanged(
                                     new FunctionBased\MultipleChecksOnAFunction(
+                                        new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\FunctionBecameInternal()),
                                         new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ParameterByReferenceChanged()),
                                         new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ReturnTypeByReferenceChanged()),
                                         new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\RequiredParameterAmountIncreased()),
@@ -248,14 +257,19 @@ use function file_exists;
                         ))
                     )
                 ))
-            ),
-            new TraitBased\MultipleChecksOnATrait(
+            ))),
+            new TraitBased\SkipTraitBasedErrors(new TraitBased\ExcludeInternalTrait(new TraitBased\MultipleChecksOnATrait(
                 new TraitBased\SkipTraitBasedErrors(new TraitBased\TraitBecameInterface()),
                 new TraitBased\SkipTraitBasedErrors(new TraitBased\TraitBecameClass()),
                 new TraitBased\SkipTraitBasedErrors(new TraitBased\UseClassBasedChecksOnATrait(
                     new ClassBased\MultipleChecksOnAClass(
+                        new ClassBased\SkipClassBasedErrors(new ClassBased\ClassBecameInternal()),
+                        new ClassBased\SkipClassBasedErrors(new ClassBased\ConstantRemoved()),
+                        new ClassBased\SkipClassBasedErrors(new ClassBased\PropertyRemoved()),
+                        new ClassBased\SkipClassBasedErrors(new ClassBased\MethodRemoved()),
                         new ClassBased\SkipClassBasedErrors(new ClassBased\PropertyChanged(
                             new PropertyBased\MultipleChecksOnAProperty(
+                                new PropertyBased\SkipPropertyBasedErrors(new PropertyBased\PropertyBecameInternal()),
                                 new PropertyBased\SkipPropertyBasedErrors(new PropertyBased\PropertyDocumentedTypeChanged()),
                                 new PropertyBased\SkipPropertyBasedErrors(new PropertyBased\PropertyDefaultValueChanged()),
                                 new PropertyBased\SkipPropertyBasedErrors(new PropertyBased\PropertyVisibilityReduced()),
@@ -271,6 +285,7 @@ use function file_exists;
                                     new MethodBased\SkipMethodBasedErrors(new MethodBased\MethodVisibilityReduced()),
                                     new MethodBased\SkipMethodBasedErrors(new MethodBased\MethodFunctionDefinitionChanged(
                                         new FunctionBased\MultipleChecksOnAFunction(
+                                            new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\FunctionBecameInternal()),
                                             new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ParameterByReferenceChanged()),
                                             new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ReturnTypeByReferenceChanged()),
                                             new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\RequiredParameterAmountIncreased()),
@@ -286,7 +301,7 @@ use function file_exists;
                         ))
                     )
                 ))
-            )
+            )))
         )
     );
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "roave/backward-compatibility-check",
     "description": "Tool to compare two revisions of a public API to check for BC breaks",
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "ext-json": "*",
         "beberlei/assert": "^3.2.1",
         "composer/composer": "^1.8.5",
@@ -25,16 +25,16 @@
     ],
     "require-dev": {
         "doctrine/coding-standard": "^6.0.0",
-        "infection/infection": "^0.13.1",
-        "phpstan/phpstan": "^0.11.8",
+        "infection/infection": "^0.13.4",
+        "phpstan/phpstan": "^0.11.12",
         "phpstan/phpstan-beberlei-assert": "^0.11.1",
         "phpstan/phpstan-phpunit": "^0.11.2",
-        "phpunit/phpunit": "^8.2.3",
+        "phpunit/phpunit": "^8.2.5",
         "psalm/plugin-phpunit": "^0.6.0",
         "roave/security-advisories": "dev-master",
         "squizlabs/php_codesniffer": "^3.4.2",
-        "thecodingmachine/phpstan-safe-rule": "^0.1.3",
-        "vimeo/psalm": "^3.4.7"
+        "thecodingmachine/phpstan-safe-rule": "^0.1.4",
+        "vimeo/psalm": "^3.4.9"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d11494368836cafe241af8f3aefa6f2e",
+    "content-hash": "ac832ed274b7436aa3d098938fad6931",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -119,16 +119,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "1.8.5",
+            "version": "1.8.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "949b116f9e7d98d8d276594fed74b580d125c0e6"
+                "reference": "19b5f66a0e233eb944f134df34091fe1c5dfcc11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/949b116f9e7d98d8d276594fed74b580d125c0e6",
-                "reference": "949b116f9e7d98d8d276594fed74b580d125c0e6",
+                "url": "https://api.github.com/repos/composer/composer/zipball/19b5f66a0e233eb944f134df34091fe1c5dfcc11",
+                "reference": "19b5f66a0e233eb944f134df34091fe1c5dfcc11",
                 "shasum": ""
             },
             "require": {
@@ -195,7 +195,7 @@
                 "dependency",
                 "package"
             ],
-            "time": "2019-04-09T15:46:48+00:00"
+            "time": "2019-06-11T13:03:06+00:00"
         },
         {
             "name": "composer/semver",
@@ -1093,16 +1093,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v4.3.1",
+            "version": "v4.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "bf2af40d738dec5e433faea7b00daa4431d0a4cf"
+                "reference": "b9896d034463ad6fd2bf17e2bf9418caecd6313d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/bf2af40d738dec5e433faea7b00daa4431d0a4cf",
-                "reference": "bf2af40d738dec5e433faea7b00daa4431d0a4cf",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b9896d034463ad6fd2bf17e2bf9418caecd6313d",
+                "reference": "b9896d034463ad6fd2bf17e2bf9418caecd6313d",
                 "shasum": ""
             },
             "require": {
@@ -1139,20 +1139,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2019-06-03T20:27:40+00:00"
+            "time": "2019-06-23T08:51:25+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v4.3.1",
+            "version": "v4.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "b3d4f4c0e4eadfdd8b296af9ca637cfbf51d8176"
+                "reference": "33c21f7d5d3dc8a140c282854a7e13aeb5d0f91a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/b3d4f4c0e4eadfdd8b296af9ca637cfbf51d8176",
-                "reference": "b3d4f4c0e4eadfdd8b296af9ca637cfbf51d8176",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/33c21f7d5d3dc8a140c282854a7e13aeb5d0f91a",
+                "reference": "33c21f7d5d3dc8a140c282854a7e13aeb5d0f91a",
                 "shasum": ""
             },
             "require": {
@@ -1188,7 +1188,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2019-05-26T20:47:49+00:00"
+            "time": "2019-06-13T11:03:18+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2066,16 +2066,16 @@
         },
         {
             "name": "infection/infection",
-            "version": "0.13.1",
+            "version": "0.13.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/infection/infection.git",
-                "reference": "a774020444a5459da2e04bf3f0552cfd06a8dcca"
+                "reference": "f0f8327f5e60d1a7d8ab4ea01074c6250ab96f57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/infection/infection/zipball/a774020444a5459da2e04bf3f0552cfd06a8dcca",
-                "reference": "a774020444a5459da2e04bf3f0552cfd06a8dcca",
+                "url": "https://api.github.com/repos/infection/infection/zipball/f0f8327f5e60d1a7d8ab4ea01074c6250ab96f57",
+                "reference": "f0f8327f5e60d1a7d8ab4ea01074c6250ab96f57",
                 "shasum": ""
             },
             "require": {
@@ -2102,6 +2102,7 @@
                 "symfony/process": "3.4.2"
             },
             "require-dev": {
+                "helmich/phpunit-json-assert": "^2.1 || ^3.0",
                 "phpunit/phpunit": "^7.5"
             },
             "bin": [
@@ -2151,7 +2152,7 @@
                 "testing",
                 "unit testing"
             ],
-            "time": "2019-05-22T05:39:05+00:00"
+            "time": "2019-07-01T18:01:41+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",
@@ -2254,16 +2255,16 @@
         },
         {
             "name": "netresearch/jsonmapper",
-            "version": "v1.5.0",
+            "version": "v1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cweiske/jsonmapper.git",
-                "reference": "da74a078d23b84134bed666df1e484d39e4f410d"
+                "reference": "047dafe26facbba1e997e9fb3b3c298562d75a0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/da74a078d23b84134bed666df1e484d39e4f410d",
-                "reference": "da74a078d23b84134bed666df1e484d39e4f410d",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/047dafe26facbba1e997e9fb3b3c298562d75a0b",
+                "reference": "047dafe26facbba1e997e9fb3b3c298562d75a0b",
                 "shasum": ""
             },
             "require": {
@@ -2292,7 +2293,7 @@
                 }
             ],
             "description": "Map nested JSON structures onto PHP classes",
-            "time": "2019-07-07T12:31:55+00:00"
+            "time": "2019-07-08T18:46:43+00:00"
         },
         {
             "name": "nette/bootstrap",
@@ -2565,16 +2566,16 @@
         },
         {
             "name": "nette/php-generator",
-            "version": "v3.2.2",
+            "version": "v3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/php-generator.git",
-                "reference": "acff8b136fad84b860a626d133e791f95781f9f5"
+                "reference": "aea6e81437bb238e5f0e5b5ce06337433908e63b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/php-generator/zipball/acff8b136fad84b860a626d133e791f95781f9f5",
-                "reference": "acff8b136fad84b860a626d133e791f95781f9f5",
+                "url": "https://api.github.com/repos/nette/php-generator/zipball/aea6e81437bb238e5f0e5b5ce06337433908e63b",
+                "reference": "aea6e81437bb238e5f0e5b5ce06337433908e63b",
                 "shasum": ""
             },
             "require": {
@@ -2620,7 +2621,7 @@
                 "php",
                 "scaffolding"
             ],
-            "time": "2019-03-15T03:41:13+00:00"
+            "time": "2019-07-05T13:01:56+00:00"
         },
         {
             "name": "nette/robot-loader",
@@ -2819,34 +2820,35 @@
         },
         {
             "name": "ocramius/package-versions",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Ocramius/PackageVersions.git",
-                "reference": "a4d4b60d0e60da2487bd21a2c6ac089f85570dbb"
+                "reference": "da0d9d34cd5df6b35756a00827aaeca7d903868d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/a4d4b60d0e60da2487bd21a2c6ac089f85570dbb",
-                "reference": "a4d4b60d0e60da2487bd21a2c6ac089f85570dbb",
+                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/da0d9d34cd5df6b35756a00827aaeca7d903868d",
+                "reference": "da0d9d34cd5df6b35756a00827aaeca7d903868d",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0.0",
-                "php": "^7.1.0"
+                "php": "^7.3.0"
             },
             "require-dev": {
-                "composer/composer": "^1.6.3",
-                "doctrine/coding-standard": "^5.0.1",
+                "composer/composer": "^1.8.6",
+                "doctrine/coding-standard": "^6.0.0",
                 "ext-zip": "*",
-                "infection/infection": "^0.7.1",
-                "phpunit/phpunit": "^7.0.0"
+                "infection/infection": "^0.13.4",
+                "phpunit/phpunit": "^8.2.5",
+                "vimeo/psalm": "^3.4.9"
             },
             "type": "composer-plugin",
             "extra": {
                 "class": "PackageVersions\\Installer",
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.6.x-dev"
                 }
             },
             "autoload": {
@@ -2865,7 +2867,7 @@
                 }
             ],
             "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
-            "time": "2019-02-21T12:16:21+00:00"
+            "time": "2019-07-17T05:00:30+00:00"
         },
         {
             "name": "openlss/lib-array2xml",
@@ -3251,16 +3253,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.11.8",
+            "version": "0.11.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "fcf0081bf3a254ddacffa03e78be87842d0c09c9"
+                "reference": "56b3eb2a371b60537fd20794e24af9e7e8ed4e30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/fcf0081bf3a254ddacffa03e78be87842d0c09c9",
-                "reference": "fcf0081bf3a254ddacffa03e78be87842d0c09c9",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/56b3eb2a371b60537fd20794e24af9e7e8ed4e30",
+                "reference": "56b3eb2a371b60537fd20794e24af9e7e8ed4e30",
                 "shasum": ""
             },
             "require": {
@@ -3273,7 +3275,7 @@
                 "nette/utils": "^2.4.5 || ^3.0",
                 "nikic/php-parser": "^4.0.2",
                 "php": "~7.1",
-                "phpstan/phpdoc-parser": "^0.3.4",
+                "phpstan/phpdoc-parser": "^0.3.5",
                 "symfony/console": "~3.2 || ~4.0",
                 "symfony/finder": "~3.2 || ~4.0"
             },
@@ -3286,6 +3288,7 @@
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
                 "ext-intl": "*",
                 "ext-mysqli": "*",
+                "ext-simplexml": "*",
                 "ext-soap": "*",
                 "ext-zip": "*",
                 "jakub-onderka/php-parallel-lint": "^1.0",
@@ -3321,7 +3324,7 @@
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
-            "time": "2019-05-28T19:58:33+00:00"
+            "time": "2019-07-08T06:55:18+00:00"
         },
         {
             "name": "phpstan/phpstan-beberlei-assert",
@@ -3435,16 +3438,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "7.0.5",
+            "version": "7.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "aed67b57d459dcab93e84a5c9703d3deb5025dff"
+                "reference": "d471d0d2b529a67c6a722dd446c4ec90881ac315"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/aed67b57d459dcab93e84a5c9703d3deb5025dff",
-                "reference": "aed67b57d459dcab93e84a5c9703d3deb5025dff",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/d471d0d2b529a67c6a722dd446c4ec90881ac315",
+                "reference": "d471d0d2b529a67c6a722dd446c4ec90881ac315",
                 "shasum": ""
             },
             "require": {
@@ -3453,17 +3456,17 @@
                 "php": "^7.2",
                 "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^3.0.1",
+                "phpunit/php-token-stream": "^3.0.2",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^4.1",
+                "sebastian/environment": "^4.2.2",
                 "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1"
+                "theseer/tokenizer": "^1.1.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.0"
+                "phpunit/phpunit": "^8.2.2"
             },
             "suggest": {
-                "ext-xdebug": "^2.6.1"
+                "ext-xdebug": "^2.7.2"
             },
             "type": "library",
             "extra": {
@@ -3494,7 +3497,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-06-06T12:28:18+00:00"
+            "time": "2019-07-08T05:29:42+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3638,16 +3641,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "c99e3be9d3e85f60646f152f9002d46ed7770d18"
+                "reference": "c4a66b97f040e3e20b3aa2a243230a1c3a9f7c8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/c99e3be9d3e85f60646f152f9002d46ed7770d18",
-                "reference": "c99e3be9d3e85f60646f152f9002d46ed7770d18",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/c4a66b97f040e3e20b3aa2a243230a1c3a9f7c8c",
+                "reference": "c4a66b97f040e3e20b3aa2a243230a1c3a9f7c8c",
                 "shasum": ""
             },
             "require": {
@@ -3683,20 +3686,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2018-10-30T05:52:18+00:00"
+            "time": "2019-07-08T05:24:54+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.2.3",
+            "version": "8.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f67ca36860ebca7224d4573f107f79bd8ed0ba03"
+                "reference": "c1b8534b3730f20f58600124129197bf1183dc92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f67ca36860ebca7224d4573f107f79bd8ed0ba03",
-                "reference": "f67ca36860ebca7224d4573f107f79bd8ed0ba03",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c1b8534b3730f20f58600124129197bf1183dc92",
+                "reference": "c1b8534b3730f20f58600124129197bf1183dc92",
                 "shasum": ""
             },
             "require": {
@@ -3723,7 +3726,7 @@
                 "sebastian/global-state": "^3.0.0",
                 "sebastian/object-enumerator": "^3.0.3",
                 "sebastian/resource-operations": "^2.0.1",
-                "sebastian/type": "^1.1.0",
+                "sebastian/type": "^1.1.3",
                 "sebastian/version": "^2.0.1"
             },
             "require-dev": {
@@ -3766,7 +3769,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-06-19T12:03:56+00:00"
+            "time": "2019-07-15T06:26:24+00:00"
         },
         {
             "name": "pimple/pimple",
@@ -3881,12 +3884,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "a53a6f855cbff7edb078f87c72bb808c89443a00"
+                "reference": "2e50fc5a89e1e77b68c7e3c3aa6d87da0b8d4c6d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/a53a6f855cbff7edb078f87c72bb808c89443a00",
-                "reference": "a53a6f855cbff7edb078f87c72bb808c89443a00",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/2e50fc5a89e1e77b68c7e3c3aa6d87da0b8d4c6d",
+                "reference": "2e50fc5a89e1e77b68c7e3c3aa6d87da0b8d4c6d",
                 "shasum": ""
             },
             "conflict": {
@@ -3989,7 +3992,7 @@
                 "silverstripe/userforms": "<3",
                 "simple-updates/phpwhois": "<=1",
                 "simplesamlphp/saml2": "<1.10.6|>=2,<2.3.8|>=3,<3.1.4",
-                "simplesamlphp/simplesamlphp": "<1.15.2|>=1.16,<1.16.3",
+                "simplesamlphp/simplesamlphp": "<1.17.3",
                 "simplesamlphp/simplesamlphp-module-infocard": "<1.0.1",
                 "slim/slim": "<2.6",
                 "smarty/smarty": "<3.1.33",
@@ -4088,7 +4091,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2019-06-25T10:37:35+00:00"
+            "time": "2019-07-14T14:21:52+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -4618,16 +4621,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "251ca774d58181fe1d3eda68843264eaae7e07ef"
+                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/251ca774d58181fe1d3eda68843264eaae7e07ef",
-                "reference": "251ca774d58181fe1d3eda68843264eaae7e07ef",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/3aaaa15fa71d27650d62a948be022fe3b48541a3",
+                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3",
                 "shasum": ""
             },
             "require": {
@@ -4660,7 +4663,7 @@
             ],
             "description": "Collection of value objects that represent the types of the PHP type system",
             "homepage": "https://github.com/sebastianbergmann/type",
-            "time": "2019-06-19T06:39:12+00:00"
+            "time": "2019-07-02T08:10:15+00:00"
         },
         {
             "name": "sebastian/version",
@@ -4798,7 +4801,7 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v4.3.1",
+            "version": "v4.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
@@ -4857,16 +4860,16 @@
         },
         {
             "name": "thecodingmachine/phpstan-safe-rule",
-            "version": "v0.1.3",
+            "version": "v0.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thecodingmachine/phpstan-safe-rule.git",
-                "reference": "00f4845905feb5240ca62fb799e3c51ba85c9230"
+                "reference": "70bfb6760b8165079d5e4a3feee9c057251cf56e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thecodingmachine/phpstan-safe-rule/zipball/00f4845905feb5240ca62fb799e3c51ba85c9230",
-                "reference": "00f4845905feb5240ca62fb799e3c51ba85c9230",
+                "url": "https://api.github.com/repos/thecodingmachine/phpstan-safe-rule/zipball/70bfb6760b8165079d5e4a3feee9c057251cf56e",
+                "reference": "70bfb6760b8165079d5e4a3feee9c057251cf56e",
                 "shasum": ""
             },
             "require": {
@@ -4879,10 +4882,15 @@
                 "phpunit/phpunit": "^7.5.2",
                 "squizlabs/php_codesniffer": "^3.4"
             },
-            "type": "library",
+            "type": "phpstan-extension",
             "extra": {
                 "branch-alias": {
                     "dev-master": "0.1-dev"
+                },
+                "phpstan": {
+                    "includes": [
+                        "phpstan-safe-rule.neon"
+                    ]
                 }
             },
             "autoload": {
@@ -4901,7 +4909,7 @@
                 }
             ],
             "description": "A PHPStan rule to detect safety issues. Must be used in conjunction with thecodingmachine/safe",
-            "time": "2019-03-07T13:52:42+00:00"
+            "time": "2019-07-15T07:34:24+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -4945,16 +4953,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "3.4.7",
+            "version": "3.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "caf7737bbe5a5e9cbdfcc1ada83ea576ca07c9ff"
+                "reference": "aa0efcf026e353ce2a4b66c4d3d81caebbf0966a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/caf7737bbe5a5e9cbdfcc1ada83ea576ca07c9ff",
-                "reference": "caf7737bbe5a5e9cbdfcc1ada83ea576ca07c9ff",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/aa0efcf026e353ce2a4b66c4d3d81caebbf0966a",
+                "reference": "aa0efcf026e353ce2a4b66c4d3d81caebbf0966a",
                 "shasum": ""
             },
             "require": {
@@ -4962,7 +4970,7 @@
                 "amphp/byte-stream": "^1.5",
                 "composer/xdebug-handler": "^1.1",
                 "felixfbecker/advanced-json-rpc": "^3.0.3",
-                "felixfbecker/language-server-protocol": "^1.3",
+                "felixfbecker/language-server-protocol": "^1.4",
                 "netresearch/jsonmapper": "^1.0",
                 "nikic/php-parser": "^4.2",
                 "ocramius/package-versions": "^1.2",
@@ -4978,6 +4986,7 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.2",
+                "friendsofphp/php-cs-fixer": "^2.15",
                 "phpmyadmin/sql-parser": "^5.0",
                 "phpunit/phpunit": "^7.5 || ^8.0",
                 "psalm/plugin-phpunit": "^0.6",
@@ -5027,7 +5036,7 @@
                 "inspection",
                 "php"
             ],
-            "time": "2019-06-28T15:25:29+00:00"
+            "time": "2019-07-09T11:39:03+00:00"
         },
         {
             "name": "webmozart/glob",
@@ -5131,7 +5140,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2",
+        "php": "^7.3",
         "ext-json": "*"
     },
     "platform-dev": []

--- a/src/CompareClasses.php
+++ b/src/CompareClasses.php
@@ -13,6 +13,7 @@ use Roave\BetterReflection\Reflector\ClassReflector;
 use Roave\BetterReflection\Reflector\Exception\IdentifierNotFound;
 use function array_filter;
 use function array_map;
+use function Safe\preg_match;
 use function Safe\sprintf;
 
 final class CompareClasses implements CompareApi
@@ -50,8 +51,8 @@ final class CompareClasses implements CompareApi
             },
             array_filter(
                 $definedSymbols->getAllClasses(),
-                static function (ReflectionClass $class) : bool {
-                    return ! $class->isAnonymous();
+                function (ReflectionClass $class) : bool {
+                    return ! ($class->isAnonymous() || $this->isInternalDocComment($class->getDocComment()));
                 }
             )
         );
@@ -107,5 +108,10 @@ final class CompareClasses implements CompareApi
         }
 
         yield from $this->classBasedComparisons->__invoke($oldSymbol, $newClass);
+    }
+
+    private function isInternalDocComment(string $comment) : bool
+    {
+        return preg_match('/\s+@internal\s+/', $comment) === 1;
     }
 }

--- a/src/DetectChanges/BCBreak/ClassBased/ClassBecameInternal.php
+++ b/src/DetectChanges/BCBreak/ClassBased/ClassBecameInternal.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BackwardCompatibility\DetectChanges\BCBreak\ClassBased;
+
+use Roave\BackwardCompatibility\Change;
+use Roave\BackwardCompatibility\Changes;
+use Roave\BetterReflection\Reflection\ReflectionClass;
+use function Safe\preg_match;
+use function Safe\sprintf;
+
+/**
+ * A class that is marked internal is no available to downstream consumers.
+ */
+final class ClassBecameInternal implements ClassBased
+{
+    public function __invoke(ReflectionClass $fromClass, ReflectionClass $toClass) : Changes
+    {
+        if ((! $this->isInternalDocComment($fromClass->getDocComment()))
+            && $this->isInternalDocComment($toClass->getDocComment())
+        ) {
+            return Changes::fromList(Change::changed(
+                sprintf(
+                    '%s was marked "@internal"',
+                    $fromClass->getName()
+                ),
+                true
+            ));
+        }
+
+        return Changes::empty();
+    }
+
+    private function isInternalDocComment(string $comment) : bool
+    {
+        return preg_match('/\s+@internal\s+/', $comment) === 1;
+    }
+}

--- a/src/DetectChanges/BCBreak/ClassBased/ClassBecameInternal.php
+++ b/src/DetectChanges/BCBreak/ClassBased/ClassBecameInternal.php
@@ -17,7 +17,7 @@ final class ClassBecameInternal implements ClassBased
 {
     public function __invoke(ReflectionClass $fromClass, ReflectionClass $toClass) : Changes
     {
-        if ((! $this->isInternalDocComment($fromClass->getDocComment()))
+        if (! $this->isInternalDocComment($fromClass->getDocComment())
             && $this->isInternalDocComment($toClass->getDocComment())
         ) {
             return Changes::fromList(Change::changed(

--- a/src/DetectChanges/BCBreak/ClassBased/ExcludeInternalClass.php
+++ b/src/DetectChanges/BCBreak/ClassBased/ExcludeInternalClass.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BackwardCompatibility\DetectChanges\BCBreak\ClassBased;
+
+use Roave\BackwardCompatibility\Changes;
+use Roave\BetterReflection\Reflection\ReflectionClass;
+use function Safe\preg_match;
+
+/**
+ * Classes marked "internal" (docblock) are not affected by BC checks.
+ */
+final class ExcludeInternalClass implements ClassBased
+{
+    /** @var ClassBased */
+    private $check;
+
+    public function __construct(ClassBased $check)
+    {
+        $this->check = $check;
+    }
+
+    public function __invoke(ReflectionClass $fromClass, ReflectionClass $toClass) : Changes
+    {
+        if ($this->isInternalDocComment($fromClass->getDocComment())) {
+            return Changes::empty();
+        }
+
+        return $this->check->__invoke($fromClass, $toClass);
+    }
+
+    private function isInternalDocComment(string $comment) : bool
+    {
+        return preg_match('/\s+@internal\s+/', $comment) === 1;
+    }
+}

--- a/src/DetectChanges/BCBreak/ClassBased/MethodRemoved.php
+++ b/src/DetectChanges/BCBreak/ClassBased/MethodRemoved.php
@@ -9,7 +9,6 @@ use Roave\BackwardCompatibility\Changes;
 use Roave\BackwardCompatibility\Formatter\ReflectionFunctionAbstractName;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionMethod;
-use function Safe\preg_match;
 use const CASE_UPPER;
 use function array_change_key_case;
 use function array_diff_key;
@@ -17,6 +16,7 @@ use function array_filter;
 use function array_map;
 use function array_values;
 use function Safe\array_combine;
+use function Safe\preg_match;
 use function Safe\sprintf;
 
 final class MethodRemoved implements ClassBased

--- a/src/DetectChanges/BCBreak/ClassBased/MethodRemoved.php
+++ b/src/DetectChanges/BCBreak/ClassBased/MethodRemoved.php
@@ -9,6 +9,7 @@ use Roave\BackwardCompatibility\Changes;
 use Roave\BackwardCompatibility\Formatter\ReflectionFunctionAbstractName;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionMethod;
+use function Safe\preg_match;
 use const CASE_UPPER;
 use function array_change_key_case;
 use function array_diff_key;
@@ -46,8 +47,10 @@ final class MethodRemoved implements ClassBased
     /** @return ReflectionMethod[] */
     private function accessibleMethods(ReflectionClass $class) : array
     {
-        $methods = array_filter($class->getMethods(), static function (ReflectionMethod $method) : bool {
-            return $method->isPublic() || $method->isProtected();
+        $methods = array_filter($class->getMethods(), function (ReflectionMethod $method) : bool {
+            return ($method->isPublic()
+                || $method->isProtected())
+                && ! $this->isInternalDocComment($method->getDocComment());
         });
 
         return array_combine(
@@ -56,5 +59,10 @@ final class MethodRemoved implements ClassBased
             }, $methods),
             $methods
         );
+    }
+
+    private function isInternalDocComment(string $comment) : bool
+    {
+        return preg_match('/\s+@internal\s+/', $comment) === 1;
     }
 }

--- a/src/DetectChanges/BCBreak/ClassBased/PropertyRemoved.php
+++ b/src/DetectChanges/BCBreak/ClassBased/PropertyRemoved.php
@@ -13,6 +13,7 @@ use function array_diff;
 use function array_filter;
 use function array_keys;
 use function array_map;
+use function Safe\preg_match;
 use function Safe\sprintf;
 
 final class PropertyRemoved implements ClassBased
@@ -44,8 +45,15 @@ final class PropertyRemoved implements ClassBased
     /** @return ReflectionProperty[] */
     private function accessibleProperties(ReflectionClass $class) : array
     {
-        return array_filter($class->getProperties(), static function (ReflectionProperty $property) : bool {
-            return $property->isPublic() || $property->isProtected();
+        return array_filter($class->getProperties(), function (ReflectionProperty $property) : bool {
+            return ($property->isPublic()
+                || $property->isProtected())
+                && ! $this->isInternalDocComment($property->getDocComment());
         });
+    }
+
+    private function isInternalDocComment(string $comment) : bool
+    {
+        return preg_match('/\s+@internal\s+/', $comment) === 1;
     }
 }

--- a/src/DetectChanges/BCBreak/FunctionBased/ExcludeInternalFunction.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/ExcludeInternalFunction.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BackwardCompatibility\DetectChanges\BCBreak\FunctionBased;
+
+use Roave\BackwardCompatibility\Changes;
+use Roave\BetterReflection\Reflection\ReflectionFunctionAbstract;
+use function Safe\preg_match;
+
+/**
+ * Functions marked "internal" (docblock) are not affected by BC checks.
+ */
+final class ExcludeInternalFunction implements FunctionBased
+{
+    /** @var FunctionBased */
+    private $check;
+
+    public function __construct(FunctionBased $check)
+    {
+        $this->check = $check;
+    }
+
+    public function __invoke(ReflectionFunctionAbstract $fromFunction, ReflectionFunctionAbstract $toFunction) : Changes
+    {
+        if ($this->isInternalDocComment($fromFunction->getDocComment())) {
+            return Changes::empty();
+        }
+
+        return $this->check->__invoke($fromFunction, $toFunction);
+    }
+
+    private function isInternalDocComment(string $comment) : bool
+    {
+        return preg_match('/\s+@internal\s+/', $comment) === 1;
+    }
+}

--- a/src/DetectChanges/BCBreak/FunctionBased/FunctionBecameInternal.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/FunctionBecameInternal.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BackwardCompatibility\DetectChanges\BCBreak\FunctionBased;
+
+use Roave\BackwardCompatibility\Change;
+use Roave\BackwardCompatibility\Changes;
+use Roave\BackwardCompatibility\Formatter\ReflectionFunctionAbstractName;
+use Roave\BetterReflection\Reflection\ReflectionFunctionAbstract;
+use function Safe\preg_match;
+use function Safe\sprintf;
+
+/**
+ * A function that is marked internal is no available to downstream consumers.
+ */
+final class FunctionBecameInternal implements FunctionBased
+{
+    /** @var ReflectionFunctionAbstractName */
+    private $formatFunction;
+
+    public function __construct()
+    {
+        $this->formatFunction = new ReflectionFunctionAbstractName();
+    }
+
+    public function __invoke(ReflectionFunctionAbstract $fromFunction, ReflectionFunctionAbstract $toFunction) : Changes
+    {
+        if ($this->isInternalDocComment($toFunction->getDocComment())
+            && ! $this->isInternalDocComment($fromFunction->getDocComment())
+        ) {
+            return Changes::fromList(Change::changed(
+                sprintf(
+                    '%s was marked "@internal"',
+                    $this->formatFunction->__invoke($fromFunction),
+                ),
+                true
+            ));
+        }
+
+        return Changes::empty();
+    }
+
+    private function isInternalDocComment(string $comment) : bool
+    {
+        return preg_match('/\s+@internal\s+/', $comment) === 1;
+    }
+}

--- a/src/DetectChanges/BCBreak/InterfaceBased/AncestorRemoved.php
+++ b/src/DetectChanges/BCBreak/InterfaceBased/AncestorRemoved.php
@@ -17,10 +17,10 @@ use function Safe\sprintf;
  */
 final class AncestorRemoved implements InterfaceBased
 {
-    public function __invoke(ReflectionClass $fromClass, ReflectionClass $toClass) : Changes
+    public function __invoke(ReflectionClass $fromInterface, ReflectionClass $toInterface) : Changes
     {
         $removedAncestors = array_merge(
-            array_diff($fromClass->getInterfaceNames(), $toClass->getInterfaceNames())
+            array_diff($fromInterface->getInterfaceNames(), $toInterface->getInterfaceNames())
         );
 
         if (! $removedAncestors) {
@@ -30,7 +30,7 @@ final class AncestorRemoved implements InterfaceBased
         return Changes::fromList(Change::removed(
             sprintf(
                 'These ancestors of %s have been removed: %s',
-                $fromClass->getName(),
+                $fromInterface->getName(),
                 json_encode($removedAncestors)
             ),
             true

--- a/src/DetectChanges/BCBreak/InterfaceBased/ExcludeInternalInterface.php
+++ b/src/DetectChanges/BCBreak/InterfaceBased/ExcludeInternalInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BackwardCompatibility\DetectChanges\BCBreak\InterfaceBased;
+
+use Roave\BackwardCompatibility\Changes;
+use Roave\BackwardCompatibility\DetectChanges\BCBreak\ClassBased\ExcludeInternalClass;
+use Roave\BetterReflection\Reflection\ReflectionClass;
+use function Safe\preg_match;
+
+/**
+ * Interfaces marked "internal" (docblock) are not affected by BC checks.
+ */
+final class ExcludeInternalInterface implements InterfaceBased
+{
+    /** @var InterfaceBased */
+    private $check;
+
+    public function __construct(InterfaceBased $check)
+    {
+        $this->check = $check;
+    }
+
+    public function __invoke(ReflectionClass $fromInterface, ReflectionClass $toInterface) : Changes
+    {
+        if ($this->isInternalDocComment($fromInterface->getDocComment())) {
+            return Changes::empty();
+        }
+
+        return $this->check->__invoke($fromInterface, $toInterface);
+    }
+
+    private function isInternalDocComment(string $comment) : bool
+    {
+        return preg_match('/\s+@internal\s+/', $comment) === 1;
+    }
+}

--- a/src/DetectChanges/BCBreak/InterfaceBased/ExcludeInternalInterface.php
+++ b/src/DetectChanges/BCBreak/InterfaceBased/ExcludeInternalInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Roave\BackwardCompatibility\DetectChanges\BCBreak\InterfaceBased;
 
 use Roave\BackwardCompatibility\Changes;
-use Roave\BackwardCompatibility\DetectChanges\BCBreak\ClassBased\ExcludeInternalClass;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use function Safe\preg_match;
 

--- a/src/DetectChanges/BCBreak/InterfaceBased/InterfaceBecameClass.php
+++ b/src/DetectChanges/BCBreak/InterfaceBased/InterfaceBecameClass.php
@@ -15,15 +15,15 @@ use function Safe\sprintf;
  */
 final class InterfaceBecameClass implements InterfaceBased
 {
-    public function __invoke(ReflectionClass $fromClass, ReflectionClass $toClass) : Changes
+    public function __invoke(ReflectionClass $fromInterface, ReflectionClass $toInterface) : Changes
     {
-        if (! $this->isClass($toClass) || ! $fromClass->isInterface()) {
+        if (! $this->isClass($toInterface) || ! $fromInterface->isInterface()) {
             // checking whether a class became an interface is done in `ClassBecameInterface`
             return Changes::empty();
         }
 
         return Changes::fromList(Change::changed(
-            sprintf('Interface %s became a class', $fromClass->getName()),
+            sprintf('Interface %s became a class', $fromInterface->getName()),
             true
         ));
     }

--- a/src/DetectChanges/BCBreak/InterfaceBased/InterfaceBecameTrait.php
+++ b/src/DetectChanges/BCBreak/InterfaceBased/InterfaceBecameTrait.php
@@ -15,15 +15,15 @@ use function Safe\sprintf;
  */
 final class InterfaceBecameTrait implements InterfaceBased
 {
-    public function __invoke(ReflectionClass $fromClass, ReflectionClass $toClass) : Changes
+    public function __invoke(ReflectionClass $fromInterface, ReflectionClass $toInterface) : Changes
     {
-        if (! $toClass->isTrait() || ! $fromClass->isInterface()) {
+        if (! $toInterface->isTrait() || ! $fromInterface->isInterface()) {
             // checking whether an interface became an class is done in `InterfaceBecameClass`
             return Changes::empty();
         }
 
         return Changes::fromList(Change::changed(
-            sprintf('Interface %s became a trait', $fromClass->getName()),
+            sprintf('Interface %s became a trait', $fromInterface->getName()),
             true
         ));
     }

--- a/src/DetectChanges/BCBreak/InterfaceBased/UseClassBasedChecksOnAnInterface.php
+++ b/src/DetectChanges/BCBreak/InterfaceBased/UseClassBasedChecksOnAnInterface.php
@@ -18,8 +18,8 @@ final class UseClassBasedChecksOnAnInterface implements InterfaceBased
         $this->check = $check;
     }
 
-    public function __invoke(ReflectionClass $fromClass, ReflectionClass $toClass) : Changes
+    public function __invoke(ReflectionClass $fromInterface, ReflectionClass $toInterface) : Changes
     {
-        return $this->check->__invoke($fromClass, $toClass);
+        return $this->check->__invoke($fromInterface, $toInterface);
     }
 }

--- a/src/DetectChanges/BCBreak/MethodBased/ExcludeInternalMethod.php
+++ b/src/DetectChanges/BCBreak/MethodBased/ExcludeInternalMethod.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Roave\BackwardCompatibility\DetectChanges\BCBreak\MethodBased;
 
 use Roave\BackwardCompatibility\Changes;
-use Roave\BetterReflection\Reflection\ReflectionFunctionAbstract;
 use Roave\BetterReflection\Reflection\ReflectionMethod;
 use function Safe\preg_match;
 

--- a/src/DetectChanges/BCBreak/MethodBased/ExcludeInternalMethod.php
+++ b/src/DetectChanges/BCBreak/MethodBased/ExcludeInternalMethod.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BackwardCompatibility\DetectChanges\BCBreak\MethodBased;
+
+use Roave\BackwardCompatibility\Changes;
+use Roave\BetterReflection\Reflection\ReflectionFunctionAbstract;
+use Roave\BetterReflection\Reflection\ReflectionMethod;
+use function Safe\preg_match;
+
+/**
+ * Methods marked "internal" (docblock) are not affected by BC checks.
+ */
+final class ExcludeInternalMethod implements MethodBased
+{
+    /** @var MethodBased */
+    private $check;
+
+    public function __construct(MethodBased $check)
+    {
+        $this->check = $check;
+    }
+
+    public function __invoke(ReflectionMethod $fromMethod, ReflectionMethod $toMethod) : Changes
+    {
+        if ($this->isInternalDocComment($fromMethod->getDocComment())) {
+            return Changes::empty();
+        }
+
+        return $this->check->__invoke($fromMethod, $toMethod);
+    }
+
+    private function isInternalDocComment(string $comment) : bool
+    {
+        return preg_match('/\s+@internal\s+/', $comment) === 1;
+    }
+}

--- a/src/DetectChanges/BCBreak/PropertyBased/ExcludeInternalProperty.php
+++ b/src/DetectChanges/BCBreak/PropertyBased/ExcludeInternalProperty.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BackwardCompatibility\DetectChanges\BCBreak\PropertyBased;
+
+use Roave\BackwardCompatibility\Changes;
+use Roave\BetterReflection\Reflection\ReflectionProperty;
+use function Safe\preg_match;
+
+final class ExcludeInternalProperty implements PropertyBased
+{
+    /** @var PropertyBased */
+    private $propertyBased;
+
+    public function __construct(PropertyBased $propertyBased)
+    {
+        $this->propertyBased = $propertyBased;
+    }
+
+    public function __invoke(ReflectionProperty $fromProperty, ReflectionProperty $toProperty) : Changes
+    {
+        if ($this->isInternalDocComment($fromProperty->getDocComment())) {
+            return Changes::empty();
+        }
+
+        return $this->propertyBased->__invoke($fromProperty, $toProperty);
+    }
+
+    private function isInternalDocComment(string $comment) : bool
+    {
+        return preg_match('/\s+@internal\s+/', $comment) === 1;
+    }
+}

--- a/src/DetectChanges/BCBreak/PropertyBased/PropertyBecameInternal.php
+++ b/src/DetectChanges/BCBreak/PropertyBased/PropertyBecameInternal.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BackwardCompatibility\DetectChanges\BCBreak\PropertyBased;
+
+use Roave\BackwardCompatibility\Change;
+use Roave\BackwardCompatibility\Changes;
+use Roave\BackwardCompatibility\Formatter\ReflectionPropertyName;
+use Roave\BetterReflection\Reflection\ReflectionProperty;
+use function Safe\preg_match;
+use function Safe\sprintf;
+
+/**
+ * A property that is marked internal is no available to downstream consumers.
+ */
+final class PropertyBecameInternal implements PropertyBased
+{
+    /** @var ReflectionPropertyName */
+    private $formatProperty;
+
+    public function __construct()
+    {
+        $this->formatProperty = new ReflectionPropertyName();
+    }
+
+    public function __invoke(ReflectionProperty $fromProperty, ReflectionProperty $toProperty) : Changes
+    {
+        if ($this->isInternalDocComment($toProperty->getDocComment())
+            && ! $this->isInternalDocComment($fromProperty->getDocComment())
+        ) {
+            return Changes::fromList(Change::changed(
+                sprintf(
+                    'Property %s was marked "@internal"',
+                    $this->formatProperty->__invoke($fromProperty),
+                ),
+                true
+            ));
+        }
+
+        return Changes::empty();
+    }
+
+    private function isInternalDocComment(string $comment) : bool
+    {
+        return preg_match('/\s+@internal\s+/', $comment) === 1;
+    }
+}

--- a/src/DetectChanges/BCBreak/TraitBased/ExcludeInternalTrait.php
+++ b/src/DetectChanges/BCBreak/TraitBased/ExcludeInternalTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BackwardCompatibility\DetectChanges\BCBreak\TraitBased;
+
+use Roave\BackwardCompatibility\Changes;
+use Roave\BetterReflection\Reflection\ReflectionClass;
+use function Safe\preg_match;
+
+/**
+ * Traits marked "internal" (docblock) are not affected by BC checks.
+ */
+final class ExcludeInternalTrait implements TraitBased
+{
+    /** @var TraitBased */
+    private $check;
+
+    public function __construct(TraitBased $check)
+    {
+        $this->check = $check;
+    }
+
+    public function __invoke(ReflectionClass $fromInterface, ReflectionClass $toInterface) : Changes
+    {
+        if ($this->isInternalDocComment($fromInterface->getDocComment())) {
+            return Changes::empty();
+        }
+
+        return $this->check->__invoke($fromInterface, $toInterface);
+    }
+
+    private function isInternalDocComment(string $comment) : bool
+    {
+        return preg_match('/\s+@internal\s+/', $comment) === 1;
+    }
+}

--- a/test/asset/api/old/ClassWithMethodsBeingRemoved.php
+++ b/test/asset/api/old/ClassWithMethodsBeingRemoved.php
@@ -33,4 +33,16 @@ class ClassWithMethodsBeingRemoved
     private function keptPrivateMethod() : void
     {
     }
+    /** @internal */
+    public function removedInternalPublicMethod() : void
+    {
+    }
+    /** @internal */
+    protected function removedInternalProtectedMethod() : void
+    {
+    }
+    /** @internal */
+    protected function removedInternalPrivateMethod() : void
+    {
+    }
 }

--- a/test/asset/api/old/ClassWithPropertiesBeingRemoved.php
+++ b/test/asset/api/old/ClassWithPropertiesBeingRemoved.php
@@ -15,4 +15,10 @@ class ClassWithPropertiesBeingRemoved
     private $removedPrivateProperty;
     private $nameCaseChangePrivateProperty;
     private $keptPrivateProperty;
+    /** @internal */
+    public $removedInternalPublicProperty;
+    /** @internal */
+    protected $removedInternalProtectedProperty;
+    /** @internal */
+    private $removedInternalPrivateProperty;
 }

--- a/test/unit/CompareClassesTest.php
+++ b/test/unit/CompareClassesTest.php
@@ -182,6 +182,32 @@ PHP
         );
     }
 
+    public function testSkipsReflectingInternalClassAlikeSymbols() : void
+    {
+        $this->classBasedComparatorWillNotBeCalled();
+        $this->interfaceBasedComparatorWillNotBeCalled();
+        $this->traitBasedComparatorWillNotBeCalled();
+
+        Assertion::assertChangesEqual(
+            Changes::empty(),
+            $this->compareClasses->__invoke(
+                self::$stringReflectorFactory->__invoke(<<<'PHP'
+<?php
+
+/** @internal */
+class A {}
+/** @internal */
+interface B {}
+/** @internal */
+trait C {}
+PHP
+                ),
+                self::$stringReflectorFactory->__invoke('<?php '),
+                self::$stringReflectorFactory->__invoke('<?php ')
+            )
+        );
+    }
+
     public function testRemovingAClassCausesABreak() : void
     {
         $this->classBasedComparatorWillNotBeCalled();

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameInternalTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameInternalTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoaveTest\BackwardCompatibility\DetectChanges\BCBreak\ClassBased;
+
+use PHPUnit\Framework\TestCase;
+use Roave\BackwardCompatibility\Change;
+use Roave\BackwardCompatibility\DetectChanges\BCBreak\ClassBased\ClassBecameInternal;
+use Roave\BetterReflection\BetterReflection;
+use Roave\BetterReflection\Reflection\ReflectionClass;
+use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
+use function array_map;
+use function iterator_to_array;
+
+/** @covers \Roave\BackwardCompatibility\DetectChanges\BCBreak\ClassBased\ClassBecameInternal */
+final class ClassBecameInternalTest extends TestCase
+{
+    /**
+     * @param string[] $expectedMessages
+     *
+     * @dataProvider classesToBeTested
+     */
+    public function testDiffs(
+        ReflectionClass $fromClass,
+        ReflectionClass $toClass,
+        array $expectedMessages
+    ) : void {
+        $changes = (new ClassBecameInternal())
+            ->__invoke($fromClass, $toClass);
+
+        self::assertSame(
+            $expectedMessages,
+            array_map(static function (Change $change) : string {
+                return $change->__toString();
+            }, iterator_to_array($changes))
+        );
+    }
+
+    /**
+     * @return array<string, array<int, ReflectionClass|array<int, string>>>
+     *
+     * @psalm-return array<string, array{0: ReflectionClass, 1: ReflectionClass, 2: array<int, string>}>
+     */
+    public function classesToBeTested() : array
+    {
+        $locator       = (new BetterReflection())->astLocator();
+        $fromReflector = new ClassReflector(new StringSourceLocator(
+            <<<'PHP'
+<?php
+
+class A {}
+class B {}
+/** @internal */
+class C {}
+/** @internal */
+class D {}
+PHP
+            ,
+            $locator
+        ));
+        $toReflector   = new ClassReflector(new StringSourceLocator(
+            <<<'PHP'
+<?php
+
+class A {}
+/** @internal */
+class B {}
+/** @internal */
+class C {}
+class D {}
+PHP
+            ,
+            $locator
+        ));
+
+        return [
+            'A' => [
+                $fromReflector->reflect('A'),
+                $toReflector->reflect('A'),
+                [],
+            ],
+            'B' => [
+                $fromReflector->reflect('B'),
+                $toReflector->reflect('B'),
+                ['[BC] CHANGED: B was marked "@internal"'],
+            ],
+            'C' => [
+                $fromReflector->reflect('C'),
+                $toReflector->reflect('C'),
+                [],
+            ],
+            'D' => [
+                $fromReflector->reflect('D'),
+                $toReflector->reflect('D'),
+                [],
+            ],
+        ];
+    }
+}

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ExcludeInternalClassTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ExcludeInternalClassTest.php
@@ -62,9 +62,6 @@ PHP
         ));
         $reflection = $reflector->reflect('AnInternalClass');
 
-        self::assertInstanceOf(ReflectionClass::class, $reflection);
-
-        /** @var ClassBased&MockObject $check */
         $check = $this->createMock(ClassBased::class);
         $check->expects(self::never())->method('__invoke');
 

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ExcludeInternalClassTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ExcludeInternalClassTest.php
@@ -11,7 +11,6 @@ use Roave\BackwardCompatibility\Changes;
 use Roave\BackwardCompatibility\DetectChanges\BCBreak\ClassBased\ClassBased;
 use Roave\BackwardCompatibility\DetectChanges\BCBreak\ClassBased\ExcludeInternalClass;
 use Roave\BetterReflection\BetterReflection;
-use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflector\ClassReflector;
 use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
 

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ExcludeInternalClassTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ExcludeInternalClassTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoaveTest\BackwardCompatibility\DetectChanges\BCBreak\ClassBased;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Roave\BackwardCompatibility\Change;
+use Roave\BackwardCompatibility\Changes;
+use Roave\BackwardCompatibility\DetectChanges\BCBreak\ClassBased\ClassBased;
+use Roave\BackwardCompatibility\DetectChanges\BCBreak\ClassBased\ExcludeInternalClass;
+use Roave\BetterReflection\BetterReflection;
+use Roave\BetterReflection\Reflection\ReflectionClass;
+use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
+
+/** @covers \Roave\BackwardCompatibility\DetectChanges\BCBreak\ClassBased\ExcludeInternalClass */
+final class ExcludeInternalClassTest extends TestCase
+{
+    public function testNormalClassesAreNotExcluded() : void
+    {
+        $locator        = (new BetterReflection())->astLocator();
+        $reflector      = new ClassReflector(new StringSourceLocator(
+            <<<'PHP'
+<?php
+
+class ANormalClass {}
+PHP
+            ,
+            $locator
+        ));
+        $fromReflection = $reflector->reflect('ANormalClass');
+        $toReflection   = $reflector->reflect('ANormalClass');
+
+        /** @var ClassBased&MockObject $check */
+        $check = $this->createMock(ClassBased::class);
+        $check->expects(self::once())
+              ->method('__invoke')
+              ->with($fromReflection, $toReflection)
+              ->willReturn(Changes::fromList(Change::removed('foo', true)));
+
+        self::assertEquals(
+            Changes::fromList(Change::removed('foo', true)),
+            (new ExcludeInternalClass($check))
+                ->__invoke($fromReflection, $toReflection)
+        );
+    }
+
+    public function testInternalClassesAreExcluded() : void
+    {
+        $locator    = (new BetterReflection())->astLocator();
+        $reflector  = new ClassReflector(new StringSourceLocator(
+            <<<'PHP'
+<?php
+
+/** @internal */
+class AnInternalClass {}
+PHP
+            ,
+            $locator
+        ));
+        $reflection = $reflector->reflect('AnInternalClass');
+
+        self::assertInstanceOf(ReflectionClass::class, $reflection);
+
+        /** @var ClassBased&MockObject $check */
+        $check = $this->createMock(ClassBased::class);
+        $check->expects(self::never())->method('__invoke');
+
+        self::assertEquals(
+            Changes::empty(),
+            (new ExcludeInternalClass($check))
+                ->__invoke($reflection, $reflection)
+        );
+    }
+}

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/ExcludeInternalFunctionTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/ExcludeInternalFunctionTest.php
@@ -19,17 +19,16 @@ final class ExcludeInternalFunctionTest extends TestCase
 {
     public function testNormalFunctionsAreNotExcluded() : void
     {
-        $astLocator = (new BetterReflection())->astLocator();
-        $source     = new StringSourceLocator(
+        $source   = new StringSourceLocator(
             <<<'PHP'
 <?php
 
 function a() {}
 PHP
             ,
-            $astLocator
+            (new BetterReflection())->astLocator()
         );
-        $function   = (new FunctionReflector($source, new ClassReflector($source, $astLocator)))
+        $function = (new FunctionReflector($source, new ClassReflector($source)))
             ->reflect('a');
 
         $check = $this->createMock(FunctionBased::class);
@@ -47,8 +46,7 @@ PHP
 
     public function testInternalFunctionsAreExcluded() : void
     {
-        $astLocator = (new BetterReflection())->astLocator();
-        $source     = new StringSourceLocator(
+        $source   = new StringSourceLocator(
             <<<'PHP'
 <?php
 
@@ -56,9 +54,9 @@ PHP
 function a() {}
 PHP
             ,
-            $astLocator
+            (new BetterReflection())->astLocator()
         );
-        $function   = (new FunctionReflector($source, new ClassReflector($source, $astLocator)))
+        $function = (new FunctionReflector($source, new ClassReflector($source)))
             ->reflect('a');
 
         $check = $this->createMock(FunctionBased::class);

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/ExcludeInternalFunctionTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/ExcludeInternalFunctionTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoaveTest\BackwardCompatibility\DetectChanges\BCBreak\FunctionBased;
+
+use PHPUnit\Framework\TestCase;
+use Roave\BackwardCompatibility\Change;
+use Roave\BackwardCompatibility\Changes;
+use Roave\BackwardCompatibility\DetectChanges\BCBreak\FunctionBased\ExcludeInternalFunction;
+use Roave\BackwardCompatibility\DetectChanges\BCBreak\FunctionBased\FunctionBased;
+use Roave\BetterReflection\BetterReflection;
+use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\Reflector\FunctionReflector;
+use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
+
+/** @covers \Roave\BackwardCompatibility\DetectChanges\BCBreak\FunctionBased\ExcludeInternalFunction */
+final class ExcludeInternalFunctionTest extends TestCase
+{
+    public function testNormalFunctionsAreNotExcluded() : void
+    {
+        $astLocator = (new BetterReflection())->astLocator();
+        $source     = new StringSourceLocator(
+            <<<'PHP'
+<?php
+
+function a() {}
+PHP
+            ,
+            $astLocator
+        );
+        $function   = (new FunctionReflector($source, new ClassReflector($source, $astLocator)))
+            ->reflect('a');
+
+        $check = $this->createMock(FunctionBased::class);
+        $check->expects(self::once())
+              ->method('__invoke')
+              ->with($function, $function)
+              ->willReturn(Changes::fromList(Change::removed('foo', true)));
+
+        self::assertEquals(
+            Changes::fromList(Change::removed('foo', true)),
+            (new ExcludeInternalFunction($check))
+                ->__invoke($function, $function)
+        );
+    }
+
+    public function testInternalFunctionsAreExcluded() : void
+    {
+        $astLocator = (new BetterReflection())->astLocator();
+        $source     = new StringSourceLocator(
+            <<<'PHP'
+<?php
+
+/** @internal */
+function a() {}
+PHP
+            ,
+            $astLocator
+        );
+        $function   = (new FunctionReflector($source, new ClassReflector($source, $astLocator)))
+            ->reflect('a');
+
+        $check = $this->createMock(FunctionBased::class);
+        $check->expects(self::never())
+              ->method('__invoke');
+
+        self::assertEquals(
+            Changes::empty(),
+            (new ExcludeInternalFunction($check))
+                ->__invoke($function, $function)
+        );
+    }
+}

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/FunctionBecameInternalTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/FunctionBecameInternalTest.php
@@ -12,6 +12,7 @@ use Roave\BetterReflection\Reflection\ReflectionFunctionAbstract;
 use Roave\BetterReflection\Reflector\ClassReflector;
 use Roave\BetterReflection\Reflector\FunctionReflector;
 use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
+use function array_keys;
 use function array_map;
 use function iterator_to_array;
 use function Safe\array_combine;
@@ -20,9 +21,9 @@ use function Safe\array_combine;
 final class FunctionBecameInternalTest extends TestCase
 {
     /**
-     * @dataProvider functionsToBeTested
-     *
      * @param string[] $expectedMessages
+     *
+     * @dataProvider functionsToBeTested
      */
     public function testDiffs(
         ReflectionFunctionAbstract $fromFunction,
@@ -34,7 +35,7 @@ final class FunctionBecameInternalTest extends TestCase
 
         self::assertSame(
             $expectedMessages,
-            array_map(function (Change $change) : string {
+            array_map(static function (Change $change) : string {
                 return $change->__toString();
             }, iterator_to_array($changes))
         );
@@ -95,7 +96,7 @@ PHP
         return array_combine(
             array_keys($functions),
             array_map(
-                function (string $function, array $errorMessages) use ($fromReflector, $toReflector) : array {
+                static function (string $function, array $errorMessages) use ($fromReflector, $toReflector) : array {
                     return [
                         $fromReflector->reflect($function),
                         $toReflector->reflect($function),

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/FunctionBecameInternalTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/FunctionBecameInternalTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoaveTest\BackwardCompatibility\DetectChanges\BCBreak\FunctionBased;
+
+use PHPUnit\Framework\TestCase;
+use Roave\BackwardCompatibility\Change;
+use Roave\BackwardCompatibility\DetectChanges\BCBreak\FunctionBased\FunctionBecameInternal;
+use Roave\BetterReflection\BetterReflection;
+use Roave\BetterReflection\Reflection\ReflectionFunctionAbstract;
+use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\Reflector\FunctionReflector;
+use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
+use function array_map;
+use function iterator_to_array;
+use function Safe\array_combine;
+
+/** @covers \Roave\BackwardCompatibility\DetectChanges\BCBreak\FunctionBased\FunctionBecameInternal */
+final class FunctionBecameInternalTest extends TestCase
+{
+    /**
+     * @dataProvider functionsToBeTested
+     *
+     * @param string[] $expectedMessages
+     */
+    public function testDiffs(
+        ReflectionFunctionAbstract $fromFunction,
+        ReflectionFunctionAbstract $toFunction,
+        array $expectedMessages
+    ) : void {
+        $changes = (new FunctionBecameInternal())
+            ->__invoke($fromFunction, $toFunction);
+
+        self::assertSame(
+            $expectedMessages,
+            array_map(function (Change $change) : string {
+                return $change->__toString();
+            }, iterator_to_array($changes))
+        );
+    }
+
+    /**
+     * @return array<string, array<int, ReflectionFunctionAbstract|array<int, string>>>
+     *
+     * @psalm-return array<string, array{0: ReflectionFunctionAbstract, 1: ReflectionFunctionAbstract, 2: array<int,
+     *               string>}>
+     */
+    public function functionsToBeTested() : array
+    {
+        $astLocator = (new BetterReflection())->astLocator();
+
+        $fromLocator = new StringSourceLocator(
+            <<<'PHP'
+<?php
+
+function a() {}
+function b() {}
+/** @internal */
+function c() {}
+/** @internal */
+function d() {}
+PHP
+            ,
+            $astLocator
+        );
+
+        $toLocator = new StringSourceLocator(
+            <<<'PHP'
+<?php
+
+function a() {}
+/** @internal */
+function b() {}
+function c() {}
+/** @internal */
+function d() {}
+PHP
+            ,
+            $astLocator
+        );
+
+        $fromClassReflector = new ClassReflector($fromLocator);
+        $toClassReflector   = new ClassReflector($toLocator);
+        $fromReflector      = new FunctionReflector($fromLocator, $fromClassReflector);
+        $toReflector        = new FunctionReflector($toLocator, $toClassReflector);
+
+        $functions = [
+            'a' => [],
+            'b' => ['[BC] CHANGED: b() was marked "@internal"'],
+            'c' => [],
+            'd' => [],
+        ];
+
+        return array_combine(
+            array_keys($functions),
+            array_map(
+                function (string $function, array $errorMessages) use ($fromReflector, $toReflector) : array {
+                    return [
+                        $fromReflector->reflect($function),
+                        $toReflector->reflect($function),
+                        $errorMessages,
+                    ];
+                },
+                array_keys($functions),
+                $functions
+            )
+        );
+    }
+}

--- a/test/unit/DetectChanges/BCBreak/InterfaceBased/ExcludeInternalInterfaceTest.php
+++ b/test/unit/DetectChanges/BCBreak/InterfaceBased/ExcludeInternalInterfaceTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoaveTest\BackwardCompatibility\DetectChanges\BCBreak\InterfaceBased;
+
+use PHPUnit\Framework\TestCase;
+use Roave\BackwardCompatibility\Change;
+use Roave\BackwardCompatibility\Changes;
+use Roave\BackwardCompatibility\DetectChanges\BCBreak\ClassBased\ExcludeInternalClass;
+use Roave\BackwardCompatibility\DetectChanges\BCBreak\InterfaceBased\ExcludeInternalInterface;
+use Roave\BackwardCompatibility\DetectChanges\BCBreak\InterfaceBased\InterfaceBased;
+use Roave\BetterReflection\BetterReflection;
+use Roave\BetterReflection\Reflection\ReflectionClass;
+use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
+
+/** @covers \Roave\BackwardCompatibility\DetectChanges\BCBreak\InterfaceBased\ExcludeInternalInterface */
+final class ExcludeInternalInterfaceTest extends TestCase
+{
+    public function testNormalInterfacesAreNotExcluded() : void
+    {
+        $locator    = (new BetterReflection())->astLocator();
+        $reflector  = new ClassReflector(new StringSourceLocator(
+            <<<'PHP'
+<?php
+
+interface ANormalInterface {}
+PHP
+            ,
+            $locator
+        ));
+        $reflection = $reflector->reflect('ANormalInterface');
+
+        $check = $this->createMock(InterfaceBased::class);
+        $check->expects(self::once())
+              ->method('__invoke')
+              ->with($reflection, $reflection)
+              ->willReturn(Changes::fromList(Change::removed('foo', true)));
+
+        self::assertEquals(
+            Changes::fromList(Change::removed('foo', true)),
+            (new ExcludeInternalInterface($check))
+                ->__invoke($reflection, $reflection)
+        );
+    }
+
+    public function testInternalInterfacesAreExcluded() : void
+    {
+        $locator    = (new BetterReflection())->astLocator();
+        $reflector  = new ClassReflector(new StringSourceLocator(
+            <<<'PHP'
+<?php
+
+/** @internal */
+interface AnInternalInterface {}
+PHP
+            ,
+            $locator
+        ));
+        $reflection = $reflector->reflect('AnInternalInterface');
+
+        self::assertInstanceOf(ReflectionClass::class, $reflection);
+
+        $check = $this->createMock(InterfaceBased::class);
+        $check->expects(self::never())->method('__invoke');
+
+        self::assertEquals(
+            Changes::empty(),
+            (new ExcludeInternalInterface($check))
+                ->__invoke($reflection, $reflection)
+        );
+    }
+}

--- a/test/unit/DetectChanges/BCBreak/InterfaceBased/ExcludeInternalInterfaceTest.php
+++ b/test/unit/DetectChanges/BCBreak/InterfaceBased/ExcludeInternalInterfaceTest.php
@@ -7,11 +7,9 @@ namespace RoaveTest\BackwardCompatibility\DetectChanges\BCBreak\InterfaceBased;
 use PHPUnit\Framework\TestCase;
 use Roave\BackwardCompatibility\Change;
 use Roave\BackwardCompatibility\Changes;
-use Roave\BackwardCompatibility\DetectChanges\BCBreak\ClassBased\ExcludeInternalClass;
 use Roave\BackwardCompatibility\DetectChanges\BCBreak\InterfaceBased\ExcludeInternalInterface;
 use Roave\BackwardCompatibility\DetectChanges\BCBreak\InterfaceBased\InterfaceBased;
 use Roave\BetterReflection\BetterReflection;
-use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflector\ClassReflector;
 use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
 

--- a/test/unit/DetectChanges/BCBreak/InterfaceBased/ExcludeInternalInterfaceTest.php
+++ b/test/unit/DetectChanges/BCBreak/InterfaceBased/ExcludeInternalInterfaceTest.php
@@ -60,8 +60,6 @@ PHP
         ));
         $reflection = $reflector->reflect('AnInternalInterface');
 
-        self::assertInstanceOf(ReflectionClass::class, $reflection);
-
         $check = $this->createMock(InterfaceBased::class);
         $check->expects(self::never())->method('__invoke');
 

--- a/test/unit/DetectChanges/BCBreak/MethodBased/ExcludeInternalMethodTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/ExcludeInternalMethodTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoaveTest\BackwardCompatibility\DetectChanges\BCBreak\MethodBased;
+
+use PHPUnit\Framework\TestCase;
+use Roave\BackwardCompatibility\Change;
+use Roave\BackwardCompatibility\Changes;
+use Roave\BackwardCompatibility\DetectChanges\BCBreak\MethodBased\ExcludeInternalMethod;
+use Roave\BackwardCompatibility\DetectChanges\BCBreak\MethodBased\MethodBased;
+use Roave\BetterReflection\BetterReflection;
+use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
+
+/** @covers \Roave\BackwardCompatibility\DetectChanges\BCBreak\MethodBased\ExcludeInternalMethod */
+final class ExcludeInternalMethodTest extends TestCase
+{
+    public function testNormalMethodsAreNotExcluded() : void
+    {
+        $method = (new ClassReflector(new StringSourceLocator(
+            <<<'PHP'
+<?php
+
+class A {
+    function method() {}
+}
+PHP
+            ,
+            (new BetterReflection())->astLocator()
+        )))
+            ->reflect('A')
+            ->getMethod('method');
+
+        $check = $this->createMock(MethodBased::class);
+        $check->expects(self::once())
+              ->method('__invoke')
+              ->with($method, $method)
+              ->willReturn(Changes::fromList(Change::removed('foo', true)));
+
+        self::assertEquals(
+            Changes::fromList(Change::removed('foo', true)),
+            (new ExcludeInternalMethod($check))
+                ->__invoke($method, $method)
+        );
+    }
+
+    public function testInternalFunctionsAreExcluded() : void
+    {
+        $method = (new ClassReflector(new StringSourceLocator(
+            <<<'PHP'
+<?php
+
+class A {
+    /** @internal */
+    function method() {}
+}
+PHP
+            ,
+            (new BetterReflection())->astLocator()
+        )))
+            ->reflect('A')
+            ->getMethod('method');
+
+        $check = $this->createMock(MethodBased::class);
+        $check->expects(self::never())
+              ->method('__invoke');
+
+        self::assertEquals(
+            Changes::empty(),
+            (new ExcludeInternalMethod($check))
+                ->__invoke($method, $method)
+        );
+    }
+}

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/ExcludeInternalPropertyTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/ExcludeInternalPropertyTest.php
@@ -32,6 +32,8 @@ PHP
             ->reflect('A')
             ->getProperty('property');
 
+        self::assertNotNull($property);
+
         $check = $this->createMock(PropertyBased::class);
         $check->expects(self::once())
               ->method('__invoke')
@@ -61,6 +63,8 @@ PHP
         )))
             ->reflect('A')
             ->getProperty('property');
+
+        self::assertNotNull($property);
 
         $check = $this->createMock(PropertyBased::class);
         $check->expects(self::never())

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/ExcludeInternalPropertyTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/ExcludeInternalPropertyTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoaveTest\BackwardCompatibility\DetectChanges\BCBreak\PropertyBased;
+
+use PHPUnit\Framework\TestCase;
+use Roave\BackwardCompatibility\Change;
+use Roave\BackwardCompatibility\Changes;
+use Roave\BackwardCompatibility\DetectChanges\BCBreak\PropertyBased\ExcludeInternalProperty;
+use Roave\BackwardCompatibility\DetectChanges\BCBreak\PropertyBased\PropertyBased;
+use Roave\BetterReflection\BetterReflection;
+use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
+
+/** @covers \Roave\BackwardCompatibility\DetectChanges\BCBreak\PropertyBased\ExcludeInternalProperty */
+final class ExcludeInternalPropertyTest extends TestCase
+{
+    public function testNormalPropertiesAreNotExcluded() : void
+    {
+        $property = (new ClassReflector(new StringSourceLocator(
+            <<<'PHP'
+<?php
+
+class A {
+    public $property;
+}
+PHP
+            ,
+            (new BetterReflection())->astLocator()
+        )))
+            ->reflect('A')
+            ->getProperty('property');
+
+        $check = $this->createMock(PropertyBased::class);
+        $check->expects(self::once())
+              ->method('__invoke')
+              ->with($property, $property)
+              ->willReturn(Changes::fromList(Change::removed('foo', true)));
+
+        self::assertEquals(
+            Changes::fromList(Change::removed('foo', true)),
+            (new ExcludeInternalProperty($check))
+                ->__invoke($property, $property)
+        );
+    }
+
+    public function testInternalPropertiesAreExcluded() : void
+    {
+        $property = (new ClassReflector(new StringSourceLocator(
+            <<<'PHP'
+<?php
+
+class A {
+    /** @internal */
+    public $property;
+}
+PHP
+            ,
+            (new BetterReflection())->astLocator()
+        )))
+            ->reflect('A')
+            ->getProperty('property');
+
+        $check = $this->createMock(PropertyBased::class);
+        $check->expects(self::never())
+              ->method('__invoke');
+
+        self::assertEquals(
+            Changes::empty(),
+            (new ExcludeInternalProperty($check))
+                ->__invoke($property, $property)
+        );
+    }
+}

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyBecameInternalTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyBecameInternalTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoaveTest\BackwardCompatibility\DetectChanges\BCBreak\PropertyBased;
+
+use PHPUnit\Framework\TestCase;
+use Roave\BackwardCompatibility\Change;
+use Roave\BackwardCompatibility\DetectChanges\BCBreak\PropertyBased\PropertyBecameInternal;
+use Roave\BackwardCompatibility\DetectChanges\BCBreak\PropertyBased\PropertyScopeChanged;
+use Roave\BetterReflection\BetterReflection;
+use Roave\BetterReflection\Reflection\ReflectionProperty;
+use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
+use function array_keys;
+use function array_map;
+use function iterator_to_array;
+use function Safe\array_combine;
+
+/**
+ * @covers \Roave\BackwardCompatibility\DetectChanges\BCBreak\PropertyBased\PropertyBecameInternal
+ */
+final class PropertyBecameInternalTest extends TestCase
+{
+    /**
+     * @param string[] $expectedMessages
+     *
+     * @dataProvider propertiesToBeTested
+     */
+    public function testDiffs(
+        ReflectionProperty $fromFunction,
+        ReflectionProperty $toFunction,
+        array $expectedMessages
+    ) : void {
+        $changes = (new PropertyBecameInternal())
+            ->__invoke($fromFunction, $toFunction);
+
+        self::assertSame(
+            $expectedMessages,
+            array_map(static function (Change $change) : string {
+                return $change->__toString();
+            }, iterator_to_array($changes))
+        );
+    }
+
+    /**
+     * @return array<string, array<int, ReflectionProperty|array<int, string>>>
+     *
+     * @psalm-return array<string, array{0: ReflectionProperty, 1: ReflectionProperty, 2: array<int, string>}>
+     */
+    public function propertiesToBeTested() : array
+    {
+        $astLocator = (new BetterReflection())->astLocator();
+
+        $fromLocator = new StringSourceLocator(
+            <<<'PHP'
+<?php
+
+class TheClass {
+    public $nonInternal;
+    public $becameInternal;
+    /** @internal */
+    public $becameNonInternal;
+    /** @internal */
+    public $stayedInternal;
+}
+PHP
+            ,
+            $astLocator
+        );
+
+        $toLocator = new StringSourceLocator(
+            <<<'PHP'
+<?php
+
+class TheClass {
+    public $nonInternal;
+    /** @internal */
+    public $becameInternal;
+    public $becameNonInternal;
+    /** @internal */
+    public $stayedInternal;
+}
+PHP
+            ,
+            $astLocator
+        );
+
+        $fromClassReflector = new ClassReflector($fromLocator);
+        $toClassReflector   = new ClassReflector($toLocator);
+        $fromClass          = $fromClassReflector->reflect('TheClass');
+        $toClass            = $toClassReflector->reflect('TheClass');
+
+        $properties = [
+            'nonInternal'       => [],
+            'becameInternal'    => ['[BC] CHANGED: Property TheClass#$becameInternal was marked "@internal"'],
+            'becameNonInternal' => [],
+            'stayedInternal'    => [],
+        ];
+
+        return array_combine(
+            array_keys($properties),
+            array_map(
+                static function (string $property, array $errorMessages) use ($fromClass, $toClass) : array {
+                    return [
+                        $fromClass->getProperty($property),
+                        $toClass->getProperty($property),
+                        $errorMessages,
+                    ];
+                },
+                array_keys($properties),
+                $properties
+            )
+        );
+    }
+}

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyBecameInternalTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyBecameInternalTest.php
@@ -7,7 +7,6 @@ namespace RoaveTest\BackwardCompatibility\DetectChanges\BCBreak\PropertyBased;
 use PHPUnit\Framework\TestCase;
 use Roave\BackwardCompatibility\Change;
 use Roave\BackwardCompatibility\DetectChanges\BCBreak\PropertyBased\PropertyBecameInternal;
-use Roave\BackwardCompatibility\DetectChanges\BCBreak\PropertyBased\PropertyScopeChanged;
 use Roave\BetterReflection\BetterReflection;
 use Roave\BetterReflection\Reflection\ReflectionProperty;
 use Roave\BetterReflection\Reflector\ClassReflector;

--- a/test/unit/DetectChanges/BCBreak/TraitBased/ExcludeInternalTraitTest.php
+++ b/test/unit/DetectChanges/BCBreak/TraitBased/ExcludeInternalTraitTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoaveTest\BackwardCompatibility\DetectChanges\BCBreak\InterfaceBased;
+
+use PHPUnit\Framework\TestCase;
+use Roave\BackwardCompatibility\Change;
+use Roave\BackwardCompatibility\Changes;
+use Roave\BackwardCompatibility\DetectChanges\BCBreak\TraitBased\ExcludeInternalTrait;
+use Roave\BackwardCompatibility\DetectChanges\BCBreak\TraitBased\TraitBased;
+use Roave\BetterReflection\BetterReflection;
+use Roave\BetterReflection\Reflection\ReflectionClass;
+use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
+
+/** @covers \Roave\BackwardCompatibility\DetectChanges\BCBreak\TraitBased\ExcludeInternalTrait */
+final class ExcludeInternalTraitTest extends TestCase
+{
+    public function testNormalTraitsAreNotExcluded() : void
+    {
+        $locator    = (new BetterReflection())->astLocator();
+        $reflector  = new ClassReflector(new StringSourceLocator(
+            <<<'PHP'
+<?php
+
+trait ANormalTrait {}
+PHP
+            ,
+            $locator
+        ));
+        $reflection = $reflector->reflect('ANormalTrait');
+
+        $check = $this->createMock(TraitBased::class);
+        $check->expects(self::once())
+              ->method('__invoke')
+              ->with($reflection, $reflection)
+              ->willReturn(Changes::fromList(Change::removed('foo', true)));
+
+        self::assertEquals(
+            Changes::fromList(Change::removed('foo', true)),
+            (new ExcludeInternalTrait($check))
+                ->__invoke($reflection, $reflection)
+        );
+    }
+
+    public function testInternalTraitsAreExcluded() : void
+    {
+        $locator    = (new BetterReflection())->astLocator();
+        $reflector  = new ClassReflector(new StringSourceLocator(
+            <<<'PHP'
+<?php
+
+/** @internal */
+trait AnInternalTrait {}
+PHP
+            ,
+            $locator
+        ));
+        $reflection = $reflector->reflect('AnInternalTrait');
+
+        self::assertInstanceOf(ReflectionClass::class, $reflection);
+
+        $check = $this->createMock(TraitBased::class);
+        $check->expects(self::never())->method('__invoke');
+
+        self::assertEquals(
+            Changes::empty(),
+            (new ExcludeInternalTrait($check))
+                ->__invoke($reflection, $reflection)
+        );
+    }
+}

--- a/test/unit/DetectChanges/BCBreak/TraitBased/ExcludeInternalTraitTest.php
+++ b/test/unit/DetectChanges/BCBreak/TraitBased/ExcludeInternalTraitTest.php
@@ -59,8 +59,6 @@ PHP
         ));
         $reflection = $reflector->reflect('AnInternalTrait');
 
-        self::assertInstanceOf(ReflectionClass::class, $reflection);
-
         $check = $this->createMock(TraitBased::class);
         $check->expects(self::never())->method('__invoke');
 

--- a/test/unit/DetectChanges/BCBreak/TraitBased/ExcludeInternalTraitTest.php
+++ b/test/unit/DetectChanges/BCBreak/TraitBased/ExcludeInternalTraitTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace RoaveTest\BackwardCompatibility\DetectChanges\BCBreak\InterfaceBased;
+namespace RoaveTest\BackwardCompatibility\DetectChanges\BCBreak\TraitBased;
 
 use PHPUnit\Framework\TestCase;
 use Roave\BackwardCompatibility\Change;

--- a/test/unit/DetectChanges/BCBreak/TraitBased/ExcludeInternalTraitTest.php
+++ b/test/unit/DetectChanges/BCBreak/TraitBased/ExcludeInternalTraitTest.php
@@ -10,7 +10,6 @@ use Roave\BackwardCompatibility\Changes;
 use Roave\BackwardCompatibility\DetectChanges\BCBreak\TraitBased\ExcludeInternalTrait;
 use Roave\BackwardCompatibility\DetectChanges\BCBreak\TraitBased\TraitBased;
 use Roave\BetterReflection\BetterReflection;
-use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflector\ClassReflector;
 use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
 


### PR DESCRIPTION
Fixes #51

Note: this is a BC break due to the defaults of the tool changing.