### PR TITLE
s/`deploy.api_key.secure`/`deploy.api_key`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,7 @@ git:
 
 deploy:
   provider: releases
-  api_key:
-    secure: $DEPLOY_TOKEN_SECURE
+  api_key: $DEPLOY_TOKEN_SECURE
   file: dist/roave-backward-compatibility-check.phar
   skip_cleanup: true
   on:


### PR DESCRIPTION
Ref: https://github.com/Roave/BackwardCompatibilityCheck/issues/169#issuecomment-562849108

Quoting:

> Inspecting the docs, I think this needs to be changed:
> 
> https://github.com/Roave/BackwardCompatibilityCheck/blob/026a96b4f523544b93f5d1228d83cd5303d7f976/.travis.yml#L29-L30
> 
> Specifically, the docs (https://docs.travis-ci.com/user/deployment/releases/) say that the format is:
> 
> ```yml
> deploy:
>   provider: releases
>   api_key: "GITHUB OAUTH TOKEN"
>   file: "FILE TO UPLOAD"
>   skip_cleanup: true
>   on:
>     tags: true
> ```

So we have a `secure:` too much there.