### PR TITLE
Upgrade nikolaposa/version to 4.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "ext-json": "*",
         "beberlei/assert": "^3.2.6",
         "composer/composer": "^1.9.0",
-        "nikolaposa/version": "@dev",
+        "nikolaposa/version": "^4.0.0",
         "ocramius/package-versions": "^1.5.1",
         "roave/better-reflection": "^3.5.0",
         "symfony/console": "^4.3.4",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "ext-json": "*",
         "beberlei/assert": "^3.2.6",
         "composer/composer": "^1.9.0",
-        "nikolaposa/version": "^3.2.0",
+        "nikolaposa/version": "@dev",
         "ocramius/package-versions": "^1.5.1",
         "roave/better-reflection": "^3.5.0",
         "symfony/console": "^4.3.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aabfb74054f2d6ee070c6b1d0c151b61",
+    "content-hash": "e0500bdcff5901d48510cc43c4874424",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -529,16 +529,16 @@
         },
         {
             "name": "nikolaposa/version",
-            "version": "dev-master",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikolaposa/version.git",
-                "reference": "cfd499d89a2ec8e84307fdbfa838936d7ac7d500"
+                "reference": "ab1aede3f84403432fe6935f7d6bfc09639d60b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikolaposa/version/zipball/cfd499d89a2ec8e84307fdbfa838936d7ac7d500",
-                "reference": "cfd499d89a2ec8e84307fdbfa838936d7ac7d500",
+                "url": "https://api.github.com/repos/nikolaposa/version/zipball/ab1aede3f84403432fe6935f7d6bfc09639d60b2",
+                "reference": "ab1aede3f84403432fe6935f7d6bfc09639d60b2",
                 "shasum": ""
             },
             "require": {
@@ -579,7 +579,7 @@
                 "version",
                 "versioning"
             ],
-            "time": "2019-12-29T10:44:06+00:00"
+            "time": "2019-12-29T15:07:37+00:00"
         },
         {
             "name": "ocramius/package-versions",
@@ -4979,7 +4979,6 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "nikolaposa/version": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": false,

--- a/composer.lock
+++ b/composer.lock
@@ -533,12 +533,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikolaposa/version.git",
-                "reference": "fcfaba80216720e6881834ffb53f83ae717ce11b"
+                "reference": "cfd499d89a2ec8e84307fdbfa838936d7ac7d500"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikolaposa/version/zipball/fcfaba80216720e6881834ffb53f83ae717ce11b",
-                "reference": "fcfaba80216720e6881834ffb53f83ae717ce11b",
+                "url": "https://api.github.com/repos/nikolaposa/version/zipball/cfd499d89a2ec8e84307fdbfa838936d7ac7d500",
+                "reference": "cfd499d89a2ec8e84307fdbfa838936d7ac7d500",
                 "shasum": ""
             },
             "require": {
@@ -579,7 +579,7 @@
                 "version",
                 "versioning"
             ],
-            "time": "2019-12-29T10:15:58+00:00"
+            "time": "2019-12-29T10:44:06+00:00"
         },
         {
             "name": "ocramius/package-versions",

--- a/composer.lock
+++ b/composer.lock
@@ -533,12 +533,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikolaposa/version.git",
-                "reference": "614e1d5cf13472747893374b7e66c94d0f8c9fe7"
+                "reference": "2cc2434a9973dc09b7a776eb1bd6b68deb735fb9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikolaposa/version/zipball/614e1d5cf13472747893374b7e66c94d0f8c9fe7",
-                "reference": "614e1d5cf13472747893374b7e66c94d0f8c9fe7",
+                "url": "https://api.github.com/repos/nikolaposa/version/zipball/2cc2434a9973dc09b7a776eb1bd6b68deb735fb9",
+                "reference": "2cc2434a9973dc09b7a776eb1bd6b68deb735fb9",
                 "shasum": ""
             },
             "require": {
@@ -579,7 +579,7 @@
                 "version",
                 "versioning"
             ],
-            "time": "2019-12-14T11:07:53+00:00"
+            "time": "2019-12-28T09:47:14+00:00"
         },
         {
             "name": "ocramius/package-versions",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "072ed72d79635eef71ac5adbea522391",
+    "content-hash": "aabfb74054f2d6ee070c6b1d0c151b61",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -529,29 +529,30 @@
         },
         {
             "name": "nikolaposa/version",
-            "version": "3.2.0",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikolaposa/version.git",
-                "reference": "7ff2bbf2fe6a47efe47832d6198924e99b4a4f5a"
+                "reference": "614e1d5cf13472747893374b7e66c94d0f8c9fe7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikolaposa/version/zipball/7ff2bbf2fe6a47efe47832d6198924e99b4a4f5a",
-                "reference": "7ff2bbf2fe6a47efe47832d6198924e99b4a4f5a",
+                "url": "https://api.github.com/repos/nikolaposa/version/zipball/614e1d5cf13472747893374b7e66c94d0f8c9fe7",
+                "reference": "614e1d5cf13472747893374b7e66c94d0f8c9fe7",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.0"
+                "beberlei/assert": "^3.2",
+                "php": "^7.2"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.0",
-                "phpunit/phpunit": "^6.0 || ^7.0"
+                "friendsofphp/php-cs-fixer": "^2.1",
+                "phpunit/phpunit": "^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -578,7 +579,7 @@
                 "version",
                 "versioning"
             ],
-            "time": "2019-08-11T08:31:54+00:00"
+            "time": "2019-12-14T11:07:53+00:00"
         },
         {
             "name": "ocramius/package-versions",
@@ -3723,12 +3724,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "9986511fcd47e8b8ec491884cc18beee1773548a"
+                "reference": "e4ee2c8e4ccd908debc64069faf023c684a76760"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/9986511fcd47e8b8ec491884cc18beee1773548a",
-                "reference": "9986511fcd47e8b8ec491884cc18beee1773548a",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/e4ee2c8e4ccd908debc64069faf023c684a76760",
+                "reference": "e4ee2c8e4ccd908debc64069faf023c684a76760",
                 "shasum": ""
             },
             "conflict": {
@@ -3933,7 +3934,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2019-11-29T17:22:08+00:00"
+            "time": "2019-12-02T13:03:15+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -4978,6 +4979,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "nikolaposa/version": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": false,

--- a/composer.lock
+++ b/composer.lock
@@ -533,12 +533,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikolaposa/version.git",
-                "reference": "2cc2434a9973dc09b7a776eb1bd6b68deb735fb9"
+                "reference": "fcfaba80216720e6881834ffb53f83ae717ce11b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikolaposa/version/zipball/2cc2434a9973dc09b7a776eb1bd6b68deb735fb9",
-                "reference": "2cc2434a9973dc09b7a776eb1bd6b68deb735fb9",
+                "url": "https://api.github.com/repos/nikolaposa/version/zipball/fcfaba80216720e6881834ffb53f83ae717ce11b",
+                "reference": "fcfaba80216720e6881834ffb53f83ae717ce11b",
                 "shasum": ""
             },
             "require": {
@@ -579,7 +579,7 @@
                 "version",
                 "versioning"
             ],
-            "time": "2019-12-28T09:47:14+00:00"
+            "time": "2019-12-29T10:15:58+00:00"
         },
         {
             "name": "ocramius/package-versions",

--- a/src/Command/AssertBackwardsCompatible.php
+++ b/src/Command/AssertBackwardsCompatible.php
@@ -226,7 +226,7 @@ USAGE
         Assert::that($versions->count())
             ->greaterThan(0, 'Could not detect any released versions for the given repository');
 
-        $versionString = $this->pickFromVersion->forVersions($versions)->getVersionString();
+        $versionString = $this->pickFromVersion->forVersions($versions)->toString();
 
         $output->writeln(sprintf('Detected last minor version: %s', $versionString));
 

--- a/src/Git/GetVersionCollection.php
+++ b/src/Git/GetVersionCollection.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Roave\BackwardCompatibility\Git;
 
-use Version\VersionsCollection;
+use Version\VersionCollection;
 
 interface GetVersionCollection
 {
-    public function fromRepository(CheckedOutRepository $repository) : VersionsCollection;
+    public function fromRepository(CheckedOutRepository $repository) : VersionCollection;
 }

--- a/src/Git/GetVersionCollectionFromGitRepository.php
+++ b/src/Git/GetVersionCollectionFromGitRepository.php
@@ -8,9 +8,9 @@ use Symfony\Component\Process\Exception\LogicException;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Exception\RuntimeException;
 use Symfony\Component\Process\Process;
-use Version\Exception\InvalidVersionStringException;
+use Version\Exception\InvalidVersionString;
 use Version\Version;
-use Version\VersionsCollection;
+use Version\VersionCollection;
 use function array_filter;
 use function array_map;
 use function explode;
@@ -24,18 +24,18 @@ final class GetVersionCollectionFromGitRepository implements GetVersionCollectio
      * @throws LogicException
      * @throws RuntimeException
      */
-    public function fromRepository(CheckedOutRepository $checkedOutRepository) : VersionsCollection
+    public function fromRepository(CheckedOutRepository $checkedOutRepository) : VersionCollection
     {
         $output = (new Process(['git', 'tag', '-l']))
             ->setWorkingDirectory($checkedOutRepository->__toString())
             ->mustRun()
             ->getOutput();
 
-        return new VersionsCollection(...array_filter(
+        return new VersionCollection(...array_filter(
             array_map(static function (string $maybeVersion) : ?Version {
                 try {
                     return Version::fromString($maybeVersion);
-                } catch (InvalidVersionStringException $e) {
+                } catch (InvalidVersionString $e) {
                     return null;
                 }
             }, explode("\n", $output))

--- a/src/Git/PickVersionFromVersionCollection.php
+++ b/src/Git/PickVersionFromVersionCollection.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Roave\BackwardCompatibility\Git;
 
 use Version\Version;
-use Version\VersionsCollection;
+use Version\VersionCollection;
 
 interface PickVersionFromVersionCollection
 {
-    public function forVersions(VersionsCollection $versionsCollection) : Version;
+    public function forVersions(VersionCollection $versionsCollection) : Version;
 }

--- a/test/unit/Command/AssertBackwardsCompatibleTest.php
+++ b/test/unit/Command/AssertBackwardsCompatibleTest.php
@@ -26,7 +26,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Version\Version;
-use Version\VersionsCollection;
+use Version\VersionCollection;
 use function Safe\chdir;
 use function Safe\realpath;
 use function sha1;
@@ -320,7 +320,7 @@ final class AssertBackwardsCompatibleTest extends TestCase
             ->getVersions
             ->expects(self::once())
             ->method('fromRepository')
-            ->willReturn(new VersionsCollection());
+            ->willReturn(new VersionCollection());
         $this
             ->pickVersion
             ->expects(self::never())
@@ -336,9 +336,9 @@ final class AssertBackwardsCompatibleTest extends TestCase
     }
 
     /**
-     * @dataProvider validVersionsCollections
+     * @dataProvider validVersionCollections
      */
-    public function testExecuteWithDefaultRevisionsNotProvided(VersionsCollection $versions) : void
+    public function testExecuteWithDefaultRevisionsNotProvided(VersionCollection $versions) : void
     {
         $fromSha       = sha1('fromRevision', false);
         $toSha         = sha1('toRevision', false);
@@ -404,22 +404,22 @@ final class AssertBackwardsCompatibleTest extends TestCase
         self::assertSame(0, $this->compare->execute($this->input, $this->output));
     }
 
-    /** @return VersionsCollection[][] */
-    public function validVersionsCollections() : array
+    /** @return VersionCollection[][] */
+    public function validVersionCollections() : array
     {
         return [
-            [new VersionsCollection(
+            [new VersionCollection(
                 Version::fromString('1.0.0'),
                 Version::fromString('1.0.1'),
                 Version::fromString('1.0.2')
             ),
             ],
-            [new VersionsCollection(
+            [new VersionCollection(
                 Version::fromString('1.0.0'),
                 Version::fromString('1.0.1')
             ),
             ],
-            [new VersionsCollection(Version::fromString('1.0.0'))],
+            [new VersionCollection(Version::fromString('1.0.0'))],
         ];
     }
 }

--- a/test/unit/Git/GetVersionCollectionFromGitRepositoryTest.php
+++ b/test/unit/Git/GetVersionCollectionFromGitRepositoryTest.php
@@ -50,7 +50,7 @@ final class GetVersionCollectionFromGitRepositoryTest extends TestCase
     {
         return array_map(
             static function (Version $version) : string {
-                return $version->getVersionString();
+                return $version->toString();
             },
             iterator_to_array((new GetVersionCollectionFromGitRepository())->fromRepository($this->repoPath))
         );

--- a/test/unit/Git/GetVersionCollectionFromGitRepositoryTest.php
+++ b/test/unit/Git/GetVersionCollectionFromGitRepositoryTest.php
@@ -76,6 +76,6 @@ final class GetVersionCollectionFromGitRepositoryTest extends TestCase
     {
         $this->makeTag('v1.0.0');
 
-        self::assertSame(['1.0.0'], $this->getTags());
+        self::assertSame(['v1.0.0'], $this->getTags());
     }
 }

--- a/test/unit/Git/PickLastMinorVersionFromCollectionTest.php
+++ b/test/unit/Git/PickLastMinorVersionFromCollectionTest.php
@@ -8,7 +8,7 @@ use Assert\AssertionFailedException;
 use PHPUnit\Framework\TestCase;
 use Roave\BackwardCompatibility\Git\PickLastMinorVersionFromCollection;
 use Version\Version;
-use Version\VersionsCollection;
+use Version\VersionCollection;
 use function array_map;
 
 /**
@@ -48,10 +48,10 @@ final class PickLastMinorVersionFromCollectionTest extends TestCase
         self::assertSame(
             $expectedVersion,
             (new PickLastMinorVersionFromCollection())->forVersions(
-                new VersionsCollection(...array_map(static function (string $version) : Version {
+                new VersionCollection(...array_map(static function (string $version) : Version {
                     return Version::fromString($version);
                 }, $collectionOfVersions))
-            )->getVersionString()
+            )->toString()
         );
     }
 
@@ -61,6 +61,6 @@ final class PickLastMinorVersionFromCollectionTest extends TestCase
 
         $this->expectException(AssertionFailedException::class);
 
-        $pick->forVersions(new VersionsCollection());
+        $pick->forVersions(new VersionCollection());
     }
 }


### PR DESCRIPTION
### Proposed changes

Synchronize with changes made in Version 4.0.0 release.

- [x] fix `Version` and `VersionCollection` usage in accordance with their new API
- [x] fix assumption that input Version string prefix is not preserved when casting to string