### PR TITLE
Update github action example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@master
+            - name: fetch tags
+              run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
             - name: Roave BC Check
               uses: docker://nyholm/roave-bc-check-ga
 ```


### PR DESCRIPTION
Github actions checkout has been changed, it is now only fetching the current branch without any tags. Adding a few lines extra will help to make the action work again.