### PR TITLE
Detect BC breaks due to parameter name changes, in line with PHP 8.0 named arguments requirements

### DIFF
--- a/bin/roave-backward-compatibility-check.php
+++ b/bin/roave-backward-compatibility-check.php
@@ -149,7 +149,8 @@ use function file_exists;
                                                     new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ReturnTypeCovarianceChanged(new TypeIsCovariant())),
                                                     new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ReturnTypeChanged()),
                                                     new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ParameterTypeContravarianceChanged(new TypeIsContravariant())),
-                                                    new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ParameterTypeChanged())
+                                                    new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ParameterTypeChanged()),
+                                                    new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ParameterNameChanged())
                                                 )
                                             ))
                                         )
@@ -170,7 +171,8 @@ use function file_exists;
                                                     new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ReturnTypeCovarianceChanged(new TypeIsCovariant())),
                                                     new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ReturnTypeChanged()),
                                                     new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ParameterTypeContravarianceChanged(new TypeIsContravariant())),
-                                                    new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ParameterTypeChanged())
+                                                    new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ParameterTypeChanged()),
+                                                    new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ParameterNameChanged())
                                                 )
                                             ))
                                         )
@@ -251,7 +253,8 @@ use function file_exists;
                                         new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ReturnTypeCovarianceChanged(new TypeIsCovariant())),
                                         new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ReturnTypeChanged()),
                                         new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ParameterTypeContravarianceChanged(new TypeIsContravariant())),
-                                        new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ParameterTypeChanged())
+                                        new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ParameterTypeChanged()),
+                                        new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ParameterNameChanged())
                                     )
                                 ))
                             )
@@ -294,7 +297,8 @@ use function file_exists;
                                             new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ReturnTypeCovarianceChanged(new TypeIsCovariant())),
                                             new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ReturnTypeChanged()),
                                             new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ParameterTypeContravarianceChanged(new TypeIsContravariant())),
-                                            new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ParameterTypeChanged())
+                                            new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ParameterTypeChanged()),
+                                            new FunctionBased\SkipFunctionBasedErrors(new FunctionBased\ParameterNameChanged())
                                         )
                                     ))
                                 )

--- a/src/DetectChanges/BCBreak/FunctionBased/ParameterNameChanged.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/ParameterNameChanged.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BackwardCompatibility\DetectChanges\BCBreak\FunctionBased;
+
+use Roave\BackwardCompatibility\Change;
+use Roave\BackwardCompatibility\Changes;
+use Roave\BackwardCompatibility\Formatter\ReflectionFunctionAbstractName;
+use Roave\BetterReflection\Reflection\ReflectionFunctionAbstract;
+use Roave\BetterReflection\Reflection\ReflectionParameter;
+
+use function array_intersect_key;
+use function Safe\sprintf;
+
+/**
+ * @todo only apply this to PHP 8+ code
+ *
+ * Detects a change in a parameter type
+ *
+ * This is mostly useful for methods, where a change in a parameter name is not allowed in
+ * inheritance/interface scenarios, except if annotated with `no-named-arguments`
+ */
+final class ParameterNameChanged implements FunctionBased
+{
+    private ReflectionFunctionAbstractName $formatFunction;
+
+    public function __construct()
+    {
+        $this->formatFunction = new ReflectionFunctionAbstractName();
+    }
+
+    public function __invoke(ReflectionFunctionAbstract $fromFunction, ReflectionFunctionAbstract $toFunction): Changes
+    {
+        return Changes::fromIterator($this->checkSymbols(
+            $fromFunction->getParameters(),
+            $toFunction->getParameters()
+        ));
+    }
+
+    /**
+     * @param ReflectionParameter[] $from
+     * @param ReflectionParameter[] $to
+     *
+     * @return iterable|Change[]
+     */
+    private function checkSymbols(array $from, array $to): iterable
+    {
+        foreach (array_intersect_key($from, $to) as $index => $commonParameter) {
+            yield from $this->compareParameter($commonParameter, $to[$index]);
+        }
+    }
+
+    /**
+     * @return iterable|Change[]
+     */
+    private function compareParameter(ReflectionParameter $fromParameter, ReflectionParameter $toParameter): iterable
+    {
+        // @todo detect if the method has a @no-named-arguments annotation, and return if so
+
+        $fromName = $fromParameter->getName();
+        $toName   = $toParameter->getName();
+
+        if ($fromName === $toName) {
+            return;
+        }
+
+        yield Change::changed(
+            sprintf(
+                'Parameter %d of %s changed name from %s to %s',
+                $fromParameter->getPosition(),
+                $this->formatFunction->__invoke($fromParameter->getDeclaringFunction()),
+                $fromName,
+                $toName
+            ),
+            true
+        );
+    }
+}

--- a/src/DetectChanges/BCBreak/FunctionBased/ParameterNameChanged.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/ParameterNameChanged.php
@@ -16,7 +16,8 @@ use function Safe\sprintf;
 /**
  * @todo only apply this to PHP 8+ code
  *
- * Detects a change in a parameter type
+ * Detects a change in a parameter name, which must now be considered a BC break as of PHP 8 (specifically, since the
+ * named parameters feature was introduced). This check can be prevented with the @no-named-arguments annotation.
  *
  * This is mostly useful for methods, where a change in a parameter name is not allowed in
  * inheritance/interface scenarios, except if annotated with `no-named-arguments`

--- a/src/DetectChanges/BCBreak/FunctionBased/ParameterNameChanged.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/ParameterNameChanged.php
@@ -15,8 +15,6 @@ use function Safe\sprintf;
 use function strpos;
 
 /**
- * @todo only apply this to PHP 8+ code
- *
  * Detects a change in a parameter name, which must now be considered a BC break as of PHP 8 (specifically, since the
  * named parameters feature was introduced). This check can be prevented with the @no-named-arguments annotation.
  *

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterNameChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterNameChangedTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoaveTest\BackwardCompatibility\DetectChanges\BCBreak\FunctionBased;
+
+use PHPUnit\Framework\TestCase;
+use Roave\BackwardCompatibility\Change;
+use Roave\BackwardCompatibility\DetectChanges\BCBreak\FunctionBased\ParameterNameChanged;
+use Roave\BetterReflection\BetterReflection;
+use Roave\BetterReflection\Reflection\ReflectionFunctionAbstract;
+use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\Reflector\FunctionReflector;
+use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
+
+use function array_combine;
+use function array_keys;
+use function array_map;
+use function iterator_to_array;
+
+/**
+ * @covers \Roave\BackwardCompatibility\DetectChanges\BCBreak\FunctionBased\ParameterNameChanged
+ */
+final class ParameterNameChangedTest extends TestCase
+{
+    /**
+     * @param string[] $expectedMessages
+     *
+     * @dataProvider functionsToBeTested
+     */
+    public function testDiffs(
+        ReflectionFunctionAbstract $fromFunction,
+        ReflectionFunctionAbstract $toFunction,
+        array $expectedMessages
+    ): void {
+        $changes = (new ParameterNameChanged())
+            ->__invoke($fromFunction, $toFunction);
+
+        self::assertSame(
+            $expectedMessages,
+            array_map(static function (Change $change): string {
+                return $change->__toString();
+            }, iterator_to_array($changes))
+        );
+    }
+
+    /**
+     * @return array<string, array<int, ReflectionFunctionAbstract|array<int, string>>>
+     *
+     * @psalm-return array<string, array{0: ReflectionFunctionAbstract, 1: ReflectionFunctionAbstract, 2: list<string>}>
+     */
+    public function functionsToBeTested(): array
+    {
+        $astLocator = (new BetterReflection())->astLocator();
+
+        $fromLocator = new StringSourceLocator(
+            <<<'PHP'
+<?php
+
+namespace {
+   function changed(int $a, int $b) {}
+   function untouched(int $a, int $b) {}
+   /** @no-named-arguments */
+   function changedButAnnotated(int $a, int $b) {}
+   /** @no-named-arguments */
+   function removingAnnotation(int $a, int $b) {}
+   function addingAnnotation(int $a, int $b) {}
+}
+PHP
+            ,
+            $astLocator
+        );
+
+        $toLocator = new StringSourceLocator(
+            <<<'PHP'
+<?php
+
+namespace {
+   function changed(int $c, int $d) {}
+   function untouched(int $a, int $b) {}
+   /** @no-named-arguments */
+   function changedButAnnotated(int $c, int $d) {}
+   function removingAnnotation(int $a, int $b) {}
+   /** @no-named-arguments */
+   function addingAnnotation(int $a, int $b) {}
+}
+PHP
+            ,
+            $astLocator
+        );
+
+        $fromClassReflector = new ClassReflector($fromLocator);
+        $toClassReflector   = new ClassReflector($toLocator);
+        $fromReflector      = new FunctionReflector($fromLocator, $fromClassReflector);
+        $toReflector        = new FunctionReflector($toLocator, $toClassReflector);
+
+        $functions = [
+            'changed'      => [
+                '[BC] CHANGED: Parameter 0 of changed() changed name from a to c',
+                '[BC] CHANGED: Parameter 1 of changed() changed name from b to d',
+            ],
+            'removingAnnotation'      => ['[BC] CHANGED: The @no-named-arguments annotation was removed from changed()'],
+        ];
+
+        return array_combine(
+            array_keys($functions),
+            array_map(
+                /** @psalm-param list<string> $errorMessages https://github.com/vimeo/psalm/issues/2772 */
+                static function (string $function, array $errorMessages) use ($fromReflector, $toReflector): array {
+                    return [
+                        $fromReflector->reflect($function),
+                        $toReflector->reflect($function),
+                        $errorMessages,
+                    ];
+                },
+                array_keys($functions),
+                $functions
+            )
+        );
+    }
+}

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterNameChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterNameChangedTest.php
@@ -99,7 +99,10 @@ PHP
                 '[BC] CHANGED: Parameter 0 of changed() changed name from a to c',
                 '[BC] CHANGED: Parameter 1 of changed() changed name from b to d',
             ],
-            'removingAnnotation'      => ['[BC] CHANGED: The @no-named-arguments annotation was removed from changed()'],
+            'untouched' => [],
+            'changedButAnnotated' => [],
+            'removingAnnotation'      => ['[BC] REMOVED: The @no-named-arguments annotation was removed from removingAnnotation()'],
+            'addingAnnotation'      => ['[BC] ADDED: The @no-named-arguments annotation was added from addingAnnotation()'],
         ];
 
         return array_combine(

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterNameChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterNameChangedTest.php
@@ -8,9 +8,9 @@ use PHPUnit\Framework\TestCase;
 use Roave\BackwardCompatibility\Change;
 use Roave\BackwardCompatibility\DetectChanges\BCBreak\FunctionBased\ParameterNameChanged;
 use Roave\BetterReflection\BetterReflection;
-use Roave\BetterReflection\Reflection\ReflectionFunctionAbstract;
-use Roave\BetterReflection\Reflector\ClassReflector;
-use Roave\BetterReflection\Reflector\FunctionReflector;
+use Roave\BetterReflection\Reflection\ReflectionFunction;
+use Roave\BetterReflection\Reflection\ReflectionMethod;
+use Roave\BetterReflection\Reflector\DefaultReflector;
 use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
 
 use function array_combine;
@@ -29,8 +29,8 @@ final class ParameterNameChangedTest extends TestCase
      * @dataProvider functionsToBeTested
      */
     public function testDiffs(
-        ReflectionFunctionAbstract $fromFunction,
-        ReflectionFunctionAbstract $toFunction,
+        ReflectionMethod|ReflectionFunction $fromFunction,
+        ReflectionMethod|ReflectionFunction $toFunction,
         array $expectedMessages
     ): void {
         $changes = (new ParameterNameChanged())
@@ -45,9 +45,11 @@ final class ParameterNameChangedTest extends TestCase
     }
 
     /**
-     * @return array<string, array<int, ReflectionFunctionAbstract|array<int, string>>>
-     *
-     * @psalm-return array<string, array{0: ReflectionFunctionAbstract, 1: ReflectionFunctionAbstract, 2: list<string>}>
+     * @return array<string, array{
+     *     0: ReflectionMethod|ReflectionFunction,
+     *     1: ReflectionMethod|ReflectionFunction,
+     *     2: list<string>
+     * }>
      */
     public function functionsToBeTested(): array
     {
@@ -89,10 +91,8 @@ PHP
             $astLocator
         );
 
-        $fromClassReflector = new ClassReflector($fromLocator);
-        $toClassReflector   = new ClassReflector($toLocator);
-        $fromReflector      = new FunctionReflector($fromLocator, $fromClassReflector);
-        $toReflector        = new FunctionReflector($toLocator, $toClassReflector);
+        $fromReflector = new DefaultReflector($fromLocator);
+        $toReflector   = new DefaultReflector($toLocator);
 
         $functions = [
             'changed'      => [
@@ -111,8 +111,8 @@ PHP
                 /** @psalm-param list<string> $errorMessages https://github.com/vimeo/psalm/issues/2772 */
                 static function (string $function, array $errorMessages) use ($fromReflector, $toReflector): array {
                     return [
-                        $fromReflector->reflect($function),
-                        $toReflector->reflect($function),
+                        $fromReflector->reflectFunction($function),
+                        $toReflector->reflectFunction($function),
                         $errorMessages,
                     ];
                 },

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterNameChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterNameChangedTest.php
@@ -67,6 +67,8 @@ namespace {
    /** @no-named-arguments */
    function removingAnnotation(int $a, int $b) {}
    function addingAnnotation(int $a, int $b) {}
+   function addedArgumentsShouldNotBeDetected($a, $b) {}
+   function removedArgumentsShouldNotBeDetected($a, $b, $c) {}
 }
 PHP
             ,
@@ -85,6 +87,8 @@ namespace {
    function removingAnnotation(int $a, int $b) {}
    /** @no-named-arguments */
    function addingAnnotation(int $a, int $b) {}
+   function addedArgumentsShouldNotBeDetected($a, $b, $c) {}
+   function removedArgumentsShouldNotBeDetected($a, $b) {}
 }
 PHP
             ,
@@ -95,27 +99,26 @@ PHP
         $toReflector   = new DefaultReflector($toLocator);
 
         $functions = [
-            'changed'      => [
+            'changed'                             => [
                 '[BC] CHANGED: Parameter 0 of changed() changed name from a to c',
                 '[BC] CHANGED: Parameter 1 of changed() changed name from b to d',
             ],
-            'untouched' => [],
-            'changedButAnnotated' => [],
-            'removingAnnotation'      => ['[BC] REMOVED: The @no-named-arguments annotation was removed from removingAnnotation()'],
-            'addingAnnotation'      => ['[BC] ADDED: The @no-named-arguments annotation was added from addingAnnotation()'],
+            'untouched'                           => [],
+            'changedButAnnotated'                 => [],
+            'removingAnnotation'                  => ['[BC] REMOVED: The @no-named-arguments annotation was removed from removingAnnotation()'],
+            'addingAnnotation'                    => ['[BC] ADDED: The @no-named-arguments annotation was added from addingAnnotation()'],
+            'addedArgumentsShouldNotBeDetected'   => [],
+            'removedArgumentsShouldNotBeDetected' => [],
         ];
 
         return array_combine(
             array_keys($functions),
             array_map(
-                /** @psalm-param list<string> $errorMessages https://github.com/vimeo/psalm/issues/2772 */
-                static function (string $function, array $errorMessages) use ($fromReflector, $toReflector): array {
-                    return [
-                        $fromReflector->reflectFunction($function),
-                        $toReflector->reflectFunction($function),
-                        $errorMessages,
-                    ];
-                },
+                static fn (string $function, array $errorMessages): array => [
+                    $fromReflector->reflectFunction($function),
+                    $toReflector->reflectFunction($function),
+                    $errorMessages,
+                ],
                 array_keys($functions),
                 $functions
             )

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterNameChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterNameChangedTest.php
@@ -59,17 +59,15 @@ final class ParameterNameChangedTest extends TestCase
             <<<'PHP'
 <?php
 
-namespace {
-   function changed(int $a, int $b) {}
-   function untouched(int $a, int $b) {}
-   /** @no-named-arguments */
-   function changedButAnnotated(int $a, int $b) {}
-   /** @no-named-arguments */
-   function removingAnnotation(int $a, int $b) {}
-   function addingAnnotation(int $a, int $b) {}
-   function addedArgumentsShouldNotBeDetected($a, $b) {}
-   function removedArgumentsShouldNotBeDetected($a, $b, $c) {}
-}
+function changed(int $a, int $b) {}
+function untouched(int $a, int $b) {}
+/** @no-named-arguments */
+function changedButAnnotated(int $a, int $b) {}
+/** @no-named-arguments */
+function removingAnnotation(int $a, int $b) {}
+function addingAnnotation(int $a, int $b) {}
+function addedArgumentsShouldNotBeDetected($a, $b) {}
+function removedArgumentsShouldNotBeDetected($a, $b, $c) {}
 PHP
             ,
             $astLocator
@@ -79,17 +77,15 @@ PHP
             <<<'PHP'
 <?php
 
-namespace {
-   function changed(int $c, int $d) {}
-   function untouched(int $a, int $b) {}
-   /** @no-named-arguments */
-   function changedButAnnotated(int $c, int $d) {}
-   function removingAnnotation(int $a, int $b) {}
-   /** @no-named-arguments */
-   function addingAnnotation(int $a, int $b) {}
-   function addedArgumentsShouldNotBeDetected($a, $b, $c) {}
-   function removedArgumentsShouldNotBeDetected($a, $b) {}
-}
+function changed(int $c, int $d) {}
+function untouched(int $a, int $b) {}
+/** @no-named-arguments */
+function changedButAnnotated(int $c, int $d) {}
+function removingAnnotation(int $a, int $b) {}
+/** @no-named-arguments */
+function addingAnnotation(int $a, int $b) {}
+function addedArgumentsShouldNotBeDetected($a, $b, $c) {}
+function removedArgumentsShouldNotBeDetected($a, $b) {}
 PHP
             ,
             $astLocator


### PR DESCRIPTION
Fixes #264 