### PR TITLE
Improve message for classes with removed traits with properties

### DIFF
--- a/src/Formatter/ReflectionPropertyName.php
+++ b/src/Formatter/ReflectionPropertyName.php
@@ -10,10 +10,16 @@ final class ReflectionPropertyName
 {
     public function __invoke(ReflectionProperty $property): string
     {
-        if ($property->isStatic()) {
-            return $property->getDeclaringClass()->getName() . '::$' . $property->getName();
+        $declaringClass = $property->getDeclaringClass();
+        $className      = $declaringClass->getName();
+        if ($declaringClass->isTrait()) {
+            $className = $property->getImplementingClass()->getName();
         }
 
-        return $property->getDeclaringClass()->getName() . '#$' . $property->getName();
+        if ($property->isStatic()) {
+            return $className . '::$' . $property->getName();
+        }
+
+        return $className . '#$' . $property->getName();
     }
 }

--- a/test/unit/DetectChanges/BCBreak/ClassBased/PropertyRemovedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/PropertyRemovedTest.php
@@ -100,6 +100,71 @@ PHP
                     '[BC] REMOVED: Property FinalClass#$removedPublicProperty was removed',
                 ],
             ],
+            'removed trait use from class' => [
+                (new ClassReflector(new StringSourceLocator(
+                    <<<'PHP'
+<?php
+
+trait PropertyTrait {
+    protected $testProperty;
+}
+
+class TestClass
+{
+    use PropertyTrait;
+}
+PHP
+                    ,
+                    $locator
+                )))->reflect('TestClass'),
+                (new ClassReflector(new StringSourceLocator(
+                    <<<'PHP'
+<?php
+
+class TestClass
+{
+}
+PHP
+                    ,
+                    $locator
+                )))->reflect('TestClass'),
+                ['[BC] REMOVED: Property TestClass#$testProperty was removed'],
+            ],
+            'removed property from trait' => [
+                (new ClassReflector(new StringSourceLocator(
+                    <<<'PHP'
+<?php
+
+trait PropertyTrait {
+    protected $testProperty;
+}
+
+class TestClass
+{
+    use PropertyTrait;
+}
+PHP
+                    ,
+                    $locator
+                )))->reflect('TestClass'),
+                (new ClassReflector(new StringSourceLocator(
+                    <<<'PHP'
+<?php
+
+trait PropertyTrait {
+    
+}
+
+class TestClass
+{
+    use PropertyTrait;
+}
+PHP
+                    ,
+                    $locator
+                )))->reflect('TestClass'),
+                ['[BC] REMOVED: Property TestClass#$testProperty was removed'],
+            ],
         ];
     }
 }

--- a/test/unit/Formatter/ReflectionPropertyNameTest.php
+++ b/test/unit/Formatter/ReflectionPropertyNameTest.php
@@ -41,9 +41,29 @@ final class ReflectionPropertyNameTest extends TestCase
 <?php
 
 namespace {
+    trait TestTrait {
+        public static $b;
+        public $c;
+    }
     class A {
         public static $b;
         public $c;
+        public $d;
+    }
+    class B {
+        use TestTrait;
+        
+        public $d;
+    }
+    class C {
+        use TestTrait;
+        
+        public $c;
+    }
+    class D extends A {
+        public $c;
+    }
+    class E extends A {
     }
 }
 namespace N1 {
@@ -61,10 +81,18 @@ PHP
 
         /** @var array<string, ReflectionProperty> $properties */
         $properties = [
-            'A::$b'    => $classReflector->reflect('A')->getProperty('b'),
-            'A#$c'     => $classReflector->reflect('A')->getProperty('c'),
-            'N1\D::$e' => $classReflector->reflect('N1\D')->getProperty('e'),
-            'N1\D#$f'  => $classReflector->reflect('N1\D')->getProperty('f'),
+            'A::$b'         => $classReflector->reflect('A')->getProperty('b'),
+            'A#$c'          => $classReflector->reflect('A')->getProperty('c'),
+            'TestTrait::$b' => $classReflector->reflect('TestTrait')->getProperty('b'),
+            'TestTrait#$c'  => $classReflector->reflect('TestTrait')->getProperty('c'),
+            'B::$b'         => $classReflector->reflect('B')->getProperty('b'),
+            'B#$c'          => $classReflector->reflect('B')->getProperty('c'),
+            'B#$d'          => $classReflector->reflect('B')->getProperty('d'),
+            'C#$c'          => $classReflector->reflect('C')->getProperty('c'),
+            'D#$c'          => $classReflector->reflect('D')->getProperty('c'),
+            'A#$d'          => $classReflector->reflect('E')->getProperty('d'),
+            'N1\D::$e'      => $classReflector->reflect('N1\D')->getProperty('e'),
+            'N1\D#$f'       => $classReflector->reflect('N1\D')->getProperty('f'),
         ];
 
         return TypeRestriction::array(array_combine(


### PR DESCRIPTION
[This PR](https://github.com/KnpLabs/php-github-api/pull/924/files#diff-8d9f29fab8b1d22b8f1b92a0be543d4b8e68ac2d475f7c3ed8da184ade8ad91f) removed a trait use from a class and the checker correctly indicated a BC break but the message was a bit confusing. So I've improved the output message for this case and added a few tests to cover this use case.

Received message:
```
[BC] REMOVED: Property Github\Api\AcceptHeaderTrait#$acceptHeaderValue was removed
```

Expected mesage:
```
[BC] REMOVED: Property Github\Api\Repository\Checks#$acceptHeaderValue was removed
```