### PR TITLE
Remove extra redundant word in reported BC break text

### DIFF
--- a/src/DetectChanges/BCBreak/FunctionBased/ParameterDefaultValueChanged.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/ParameterDefaultValueChanged.php
@@ -45,7 +45,7 @@ final class ParameterDefaultValueChanged implements FunctionBased
 
             $changes = $changes->mergeWith(Changes::fromList(Change::changed(
                 sprintf(
-                    'Default parameter value for for parameter $%s of %s changed from %s to %s',
+                    'Default parameter value for parameter $%s of %s changed from %s to %s',
                     $parameter->getName(),
                     $this->formatFunction->__invoke($fromFunction),
                     var_export($defaultValueFrom, true),

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterDefaultValueChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterDefaultValueChangedTest.php
@@ -104,18 +104,18 @@ PHP
 
         $functions = [
             'changed'            => [
-                '[BC] CHANGED: Default parameter value for for parameter $a of changed() changed from 1 to 2',
+                '[BC] CHANGED: Default parameter value for parameter $a of changed() changed from 1 to 2',
             ],
             'defaultAdded'       => [],
             'defaultRemoved'     => [],
             'defaultTypeChanged' => [
-                '[BC] CHANGED: Default parameter value for for parameter $a of defaultTypeChanged() changed from \'1\' to 1',
+                '[BC] CHANGED: Default parameter value for parameter $a of defaultTypeChanged() changed from \'1\' to 1',
             ],
             'notChanged'         => [],
             'namesChanged'       => [],
             'orderChanged'       => [
-                '[BC] CHANGED: Default parameter value for for parameter $a of orderChanged() changed from 1 to 3',
-                '[BC] CHANGED: Default parameter value for for parameter $c of orderChanged() changed from 3 to 1',
+                '[BC] CHANGED: Default parameter value for parameter $a of orderChanged() changed from 1 to 3',
+                '[BC] CHANGED: Default parameter value for parameter $c of orderChanged() changed from 3 to 1',
             ],
             'positionOfOptionalParameterChanged' => [],
         ];
@@ -141,14 +141,14 @@ PHP
                     $fromClassReflector->reflect('C')->getMethod('changed1'),
                     $toClassReflector->reflect('C')->getMethod('changed1'),
                     [
-                        '[BC] CHANGED: Default parameter value for for parameter $a of C::changed1() changed from 1 to 2',
+                        '[BC] CHANGED: Default parameter value for parameter $a of C::changed1() changed from 1 to 2',
                     ],
                 ],
                 'C#changed2'  => [
                     $fromClassReflector->reflect('C')->getMethod('changed2'),
                     $toClassReflector->reflect('C')->getMethod('changed2'),
                     [
-                        '[BC] CHANGED: Default parameter value for for parameter $a of C#changed2() changed from 1 to 2',
+                        '[BC] CHANGED: Default parameter value for parameter $a of C#changed2() changed from 1 to 2',
                     ],
                 ],
             ]


### PR DESCRIPTION
This is probably not deliberate, even if there are tests with the same issue :smile: 