### PR TITLE
Replaced at() matcher with onConsecutive stub

### DIFF
--- a/test/unit/Command/AssertBackwardsCompatibleTest.php
+++ b/test/unit/Command/AssertBackwardsCompatibleTest.php
@@ -147,29 +147,32 @@ final class AssertBackwardsCompatibleTest extends TestCase
             ['sources-path', 'src'],
         ]);
 
-        $this->performCheckout->expects(self::at(0))
+        $this->performCheckout->expects(self::exactly(2))
             ->method('checkout')
-            ->with($this->sourceRepository, $fromSha)
-            ->willReturn($this->sourceRepository);
-        $this->performCheckout->expects(self::at(1))
-            ->method('checkout')
-            ->with($this->sourceRepository, $toSha)
-            ->willReturn($this->sourceRepository);
-        $this->performCheckout->expects(self::at(2))
-            ->method('remove')
-            ->with($this->sourceRepository);
-        $this->performCheckout->expects(self::at(3))
-            ->method('remove')
-            ->with($this->sourceRepository);
+            ->withConsecutive(
+                [$this->sourceRepository, $fromSha],
+                [$this->sourceRepository, $toSha]
+            )->willReturnOnConsecutiveCalls(
+                $this->sourceRepository,
+                $this->sourceRepository
+            );
 
-        $this->parseRevision->expects(self::at(0))
+        $this->performCheckout->expects(self::exactly(2))
+            ->method('remove')
+            ->withConsecutive(
+                [$this->sourceRepository],
+                [$this->sourceRepository]
+            );
+
+        $this->parseRevision->expects(self::exactly(2))
             ->method('fromStringForRepository')
-            ->with($fromSha)
-            ->willReturn(Revision::fromSha1($fromSha));
-        $this->parseRevision->expects(self::at(1))
-            ->method('fromStringForRepository')
-            ->with($toSha)
-            ->willReturn(Revision::fromSha1($toSha));
+            ->withConsecutive(
+                [$fromSha],
+                [$toSha]
+            )->willReturnOnConsecutiveCalls(
+                Revision::fromSha1($fromSha),
+                Revision::fromSha1($toSha)
+            );
 
         $this
             ->locateDependencies
@@ -196,29 +199,32 @@ final class AssertBackwardsCompatibleTest extends TestCase
             ['sources-path', 'src'],
         ]);
 
-        $this->performCheckout->expects(self::at(0))
+        $this->performCheckout->expects(self::exactly(2))
             ->method('checkout')
-            ->with($this->sourceRepository, $fromSha)
-            ->willReturn($this->sourceRepository);
-        $this->performCheckout->expects(self::at(1))
-            ->method('checkout')
-            ->with($this->sourceRepository, $toSha)
-            ->willReturn($this->sourceRepository);
-        $this->performCheckout->expects(self::at(2))
-            ->method('remove')
-            ->with($this->sourceRepository);
-        $this->performCheckout->expects(self::at(3))
-            ->method('remove')
-            ->with($this->sourceRepository);
+            ->withConsecutive(
+                [$this->sourceRepository, $fromSha],
+                [$this->sourceRepository, $toSha]
+            )->willReturnOnConsecutiveCalls(
+                $this->sourceRepository,
+                $this->sourceRepository
+            );
 
-        $this->parseRevision->expects(self::at(0))
+        $this->performCheckout->expects(self::exactly(2))
+            ->method('remove')
+            ->withConsecutive(
+                [$this->sourceRepository],
+                [$this->sourceRepository]
+            );
+
+        $this->parseRevision->expects(self::exactly(2))
             ->method('fromStringForRepository')
-            ->with($fromSha)
-            ->willReturn(Revision::fromSha1($fromSha));
-        $this->parseRevision->expects(self::at(1))
-            ->method('fromStringForRepository')
-            ->with($toSha)
-            ->willReturn(Revision::fromSha1($toSha));
+            ->withConsecutive(
+                [$fromSha],
+                [$toSha]
+            )->willReturnOnConsecutiveCalls(
+                Revision::fromSha1($fromSha),
+                Revision::fromSha1($toSha)
+            );
 
         $this
             ->locateDependencies
@@ -258,29 +264,32 @@ final class AssertBackwardsCompatibleTest extends TestCase
             ['sources-path', 'src'],
         ]);
 
-        $this->performCheckout->expects(self::at(0))
+        $this->performCheckout->expects(self::exactly(2))
             ->method('checkout')
-            ->with($this->sourceRepository, $fromSha)
-            ->willReturn($this->sourceRepository);
-        $this->performCheckout->expects(self::at(1))
-            ->method('checkout')
-            ->with($this->sourceRepository, $toSha)
-            ->willReturn($this->sourceRepository);
-        $this->performCheckout->expects(self::at(2))
-            ->method('remove')
-            ->with($this->sourceRepository);
-        $this->performCheckout->expects(self::at(3))
-            ->method('remove')
-            ->with($this->sourceRepository);
+            ->withConsecutive(
+                [$this->sourceRepository, $fromSha],
+                [$this->sourceRepository, $toSha],
+            )->willReturnOnConsecutiveCalls(
+                $this->sourceRepository,
+                $this->sourceRepository
+            );
 
-        $this->parseRevision->expects(self::at(0))
+        $this->performCheckout->expects(self::exactly(2))
+            ->method('remove')
+            ->withConsecutive(
+                [$this->sourceRepository],
+                [$this->sourceRepository]
+            );
+
+        $this->parseRevision->expects(self::exactly(2))
             ->method('fromStringForRepository')
-            ->with($fromSha)
-            ->willReturn(Revision::fromSha1($fromSha));
-        $this->parseRevision->expects(self::at(1))
-            ->method('fromStringForRepository')
-            ->with($toSha)
-            ->willReturn(Revision::fromSha1($toSha));
+            ->withConsecutive(
+                [$fromSha],
+                [$toSha]
+            )->willReturnOnConsecutiveCalls(
+                Revision::fromSha1($fromSha),
+                Revision::fromSha1($toSha)
+            );
 
         $this
             ->locateDependencies
@@ -358,29 +367,32 @@ final class AssertBackwardsCompatibleTest extends TestCase
             ['sources-path', 'src'],
         ]);
 
-        $this->performCheckout->expects(self::at(0))
+        $this->performCheckout->expects(self::exactly(2))
             ->method('checkout')
-            ->with($this->sourceRepository, $fromSha)
-            ->willReturn($this->sourceRepository);
-        $this->performCheckout->expects(self::at(1))
-            ->method('checkout')
-            ->with($this->sourceRepository, $toSha)
-            ->willReturn($this->sourceRepository);
-        $this->performCheckout->expects(self::at(2))
-            ->method('remove')
-            ->with($this->sourceRepository);
-        $this->performCheckout->expects(self::at(3))
-            ->method('remove')
-            ->with($this->sourceRepository);
+            ->withConsecutive(
+                [$this->sourceRepository, $fromSha],
+                [$this->sourceRepository, $toSha]
+            )->willReturnOnConsecutiveCalls(
+                $this->sourceRepository,
+                $this->sourceRepository
+            );
 
-        $this->parseRevision->expects(self::at(0))
+        $this->performCheckout->expects(self::exactly(2))
+            ->method('remove')
+            ->withConsecutive(
+                [$this->sourceRepository],
+                [$this->sourceRepository]
+            );
+
+        $this->parseRevision->expects(self::exactly(2))
             ->method('fromStringForRepository')
-            ->with((string) $pickedVersion)
-            ->willReturn(Revision::fromSha1($fromSha));
-        $this->parseRevision->expects(self::at(1))
-            ->method('fromStringForRepository')
-            ->with('HEAD')
-            ->willReturn(Revision::fromSha1($toSha));
+            ->withConsecutive(
+                [(string) $pickedVersion],
+                ['HEAD']
+            )->willReturnOnConsecutiveCalls(
+                Revision::fromSha1($fromSha),
+                Revision::fromSha1($toSha)
+            );
 
         $this->getVersions->expects(self::once())
             ->method('fromRepository')

--- a/test/unit/Formatter/SymfonyConsoleTextFormatterTest.php
+++ b/test/unit/Formatter/SymfonyConsoleTextFormatterTest.php
@@ -27,12 +27,12 @@ final class SymfonyConsoleTextFormatterTest extends TestCase
         $change2Text = SecureRandom\string(8);
 
         $output = $this->createMock(OutputInterface::class);
-        $output->expects(self::at(0))
+        $output->expects(self::exactly(2))
             ->method('writeln')
-            ->with(Str\format('[BC] REMOVED: %s', $change1Text));
-        $output->expects(self::at(1))
-            ->method('writeln')
-            ->with(Str\format('     ADDED: %s', $change2Text));
+            ->withConsecutive(
+                [sprintf('[BC] REMOVED: %s', $change1Text)],
+                [sprintf('     ADDED: %s', $change2Text)]
+            );
 
         (new SymfonyConsoleTextFormatter($output))->write(Changes::fromList(
             Change::removed($change1Text, true),

--- a/test/unit/Formatter/SymfonyConsoleTextFormatterTest.php
+++ b/test/unit/Formatter/SymfonyConsoleTextFormatterTest.php
@@ -30,8 +30,8 @@ final class SymfonyConsoleTextFormatterTest extends TestCase
         $output->expects(self::exactly(2))
             ->method('writeln')
             ->withConsecutive(
-                [sprintf('[BC] REMOVED: %s', $change1Text)],
-                [sprintf('     ADDED: %s', $change2Text)]
+                [Str\format('[BC] REMOVED: %s', $change1Text)],
+                [Str\format('     ADDED: %s', $change2Text)]
             );
 
         (new SymfonyConsoleTextFormatter($output))->write(Changes::fromList(


### PR DESCRIPTION
`at()` is deprecated since PHPUnit 9.3