### PR TITLE
Added option for `--install-development-dependencies`

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -17,19 +17,6 @@
         <PropertyNotSetInConstructor errorLevel="suppress"/>
         <InternalClass errorLevel="suppress"/>
         <InternalMethod errorLevel="suppress"/>
-
-        <DeprecatedClass>
-            <errorLevel type="suppress">
-                <directory name="test"/>
-                <directory name="bin"/>
-            </errorLevel>
-        </DeprecatedClass>
-
-        <DeprecatedMethod>
-            <errorLevel type="suppress">
-                <directory name="test/"/>
-            </errorLevel>
-        </DeprecatedMethod>
     </issueHandlers>
 
     <plugins>

--- a/src/Command/AssertBackwardsCompatible.php
+++ b/src/Command/AssertBackwardsCompatible.php
@@ -96,6 +96,12 @@ final class AssertBackwardsCompatible extends Command
                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
                 'Currently only supports "markdown"'
             )
+            ->addOption(
+                'install-development-dependencies',
+                null,
+                InputOption::VALUE_NONE,
+                'Whether to also install "require-dev" dependencies too'
+            )
             ->addUsage(
                 <<<'USAGE'
 
@@ -139,6 +145,8 @@ USAGE
 
         $to = Type\string()->coerce($input->getOption('to'));
 
+        $includeDevelopmentDependencies = Type\bool()->coerce($input->getOption('install-development-dependencies'));
+
         $toRevision = $this->parseRevision->fromStringForRepository($to, $sourceRepo);
 
         $stdErr->writeln(Str\format(
@@ -158,11 +166,11 @@ USAGE
                 ),
                 $this->makeComposerInstallationReflector->__invoke(
                     $fromPath->__toString(),
-                    $this->locateDependencies->__invoke($fromPath->__toString())
+                    $this->locateDependencies->__invoke($fromPath->__toString(), $includeDevelopmentDependencies)
                 ),
                 $this->makeComposerInstallationReflector->__invoke(
                     $toPath->__toString(),
-                    $this->locateDependencies->__invoke($toPath->__toString())
+                    $this->locateDependencies->__invoke($toPath->__toString(), $includeDevelopmentDependencies)
                 )
             );
 

--- a/src/LocateDependencies/LocateDependencies.php
+++ b/src/LocateDependencies/LocateDependencies.php
@@ -8,5 +8,5 @@ use Roave\BetterReflection\SourceLocator\Type\SourceLocator;
 
 interface LocateDependencies
 {
-    public function __invoke(string $installationPath, bool $includeDevelopmentDependencies = false): SourceLocator;
+    public function __invoke(string $installationPath, bool $includeDevelopmentDependencies): SourceLocator;
 }

--- a/src/LocateDependencies/LocateDependencies.php
+++ b/src/LocateDependencies/LocateDependencies.php
@@ -8,5 +8,5 @@ use Roave\BetterReflection\SourceLocator\Type\SourceLocator;
 
 interface LocateDependencies
 {
-    public function __invoke(string $installationPath): SourceLocator;
+    public function __invoke(string $installationPath, bool $includeDevelopmentDependencies = false): SourceLocator;
 }

--- a/src/LocateDependencies/LocateDependenciesViaComposer.php
+++ b/src/LocateDependencies/LocateDependenciesViaComposer.php
@@ -34,7 +34,7 @@ final class LocateDependenciesViaComposer implements LocateDependencies
         $this->astLocator            = $astLocator;
     }
 
-    public function __invoke(string $installationPath, bool $includeDevelopmentDependencies = false): SourceLocator
+    public function __invoke(string $installationPath, bool $includeDevelopmentDependencies): SourceLocator
     {
         Psl\invariant(Filesystem\is_file($installationPath . '/composer.json'), 'Could not locate composer.json within installation path.');
 

--- a/src/LocateDependencies/LocateDependenciesViaComposer.php
+++ b/src/LocateDependencies/LocateDependenciesViaComposer.php
@@ -34,15 +34,15 @@ final class LocateDependenciesViaComposer implements LocateDependencies
         $this->astLocator            = $astLocator;
     }
 
-    public function __invoke(string $installationPath): SourceLocator
+    public function __invoke(string $installationPath, bool $includeDevelopmentDependencies = false): SourceLocator
     {
         Psl\invariant(Filesystem\is_file($installationPath . '/composer.json'), 'Could not locate composer.json within installation path.');
 
-        $this->runInDirectory(function () use ($installationPath): void {
+        $this->runInDirectory(function () use ($installationPath, $includeDevelopmentDependencies): void {
             $installer = ($this->makeComposerInstaller)($installationPath);
 
             // Some defaults needed for this specific implementation:
-            $installer->setDevMode(false);
+            $installer->setDevMode($includeDevelopmentDependencies);
             $installer->setDumpAutoloader(false);
             /**
              * @psalm-suppress DeprecatedMethod we will keep using the deprecated API until the next major release

--- a/test/unit/LocateDependencies/LocateDependenciesViaComposerTest.php
+++ b/test/unit/LocateDependencies/LocateDependenciesViaComposerTest.php
@@ -67,7 +67,7 @@ final class LocateDependenciesViaComposerTest extends TestCase
 
         $this
             ->locateDependencies
-            ->__invoke(__DIR__ . '/non-existing');
+            ->__invoke(__DIR__ . '/non-existing', false);
     }
 
     public function testWillLocateDependencies(): void
@@ -106,7 +106,7 @@ final class LocateDependenciesViaComposerTest extends TestCase
 
         $locator = $this
             ->locateDependencies
-            ->__invoke($this->expectedInstallationPath);
+            ->__invoke($this->expectedInstallationPath, false);
 
         self::assertInstanceOf(AggregateSourceLocator::class, $locator);
 


### PR DESCRIPTION
Adds a new option `--install-development-dependencies` to the CLI runner, which, when explicitly set, will install `require-dev` dependencies in the package being checked.

Use case for this: I maintain a library which has optional dependencies (which are included in `require-dev` and `suggest`), but I cannot run `Roave/BackwardCompatibilityCheck` on it, since it fails to find the optional classes.

Introduced BC break:

```

[BC] CHANGED: The number of required arguments for Roave\BackwardCompatibility\LocateDependencies\LocateDependenciesViaComposer#__invoke() increased from 1 to 2
[BC] CHANGED: The number of required arguments for Roave\BackwardCompatibility\LocateDependencies\LocateDependencies#__invoke() increased from 1 to 2
```