### PR TITLE
Use native invocations instead of explicit `__invoke()`

### DIFF
--- a/src/Command/AssertBackwardsCompatible.php
+++ b/src/Command/AssertBackwardsCompatible.php
@@ -159,18 +159,18 @@ USAGE
         $toPath   = $this->git->checkout($sourceRepo, $toRevision);
 
         try {
-            $changes = $this->compareApi->__invoke(
-                $this->makeComposerInstallationReflector->__invoke(
+            $changes = ($this->compareApi)(
+                ($this->makeComposerInstallationReflector)(
                     $fromPath->__toString(),
                     new AggregateSourceLocator() // no dependencies
                 ),
-                $this->makeComposerInstallationReflector->__invoke(
+                ($this->makeComposerInstallationReflector)(
                     $fromPath->__toString(),
-                    $this->locateDependencies->__invoke($fromPath->__toString(), $includeDevelopmentDependencies)
+                    ($this->locateDependencies)($fromPath->__toString(), $includeDevelopmentDependencies)
                 ),
-                $this->makeComposerInstallationReflector->__invoke(
+                ($this->makeComposerInstallationReflector)(
                     $toPath->__toString(),
-                    $this->locateDependencies->__invoke($toPath->__toString(), $includeDevelopmentDependencies)
+                    ($this->locateDependencies)($toPath->__toString(), $includeDevelopmentDependencies)
                 )
             );
 

--- a/src/CompareClasses.php
+++ b/src/CompareClasses.php
@@ -87,18 +87,18 @@ final class CompareClasses implements CompareApi
         }
 
         if ($oldSymbol->isInterface()) {
-            yield from $this->interfaceBasedComparisons->__invoke($oldSymbol, $newClass);
+            yield from ($this->interfaceBasedComparisons)($oldSymbol, $newClass);
 
             return;
         }
 
         if ($oldSymbol->isTrait()) {
-            yield from $this->traitBasedComparisons->__invoke($oldSymbol, $newClass);
+            yield from ($this->traitBasedComparisons)($oldSymbol, $newClass);
 
             return;
         }
 
-        yield from $this->classBasedComparisons->__invoke($oldSymbol, $newClass);
+        yield from ($this->classBasedComparisons)($oldSymbol, $newClass);
     }
 
     private function isInternalDocComment(string $comment): bool

--- a/src/DetectChanges/BCBreak/ClassBased/ConstantChanged.php
+++ b/src/DetectChanges/BCBreak/ClassBased/ConstantChanged.php
@@ -38,7 +38,7 @@ final class ConstantChanged implements ClassBased
     private function checkSymbols(array $from, array $to): iterable
     {
         foreach (Vec\keys(Dict\intersect_by_key($from, $to)) as $name) {
-            yield from $this->checkConstant->__invoke($from[$name], $to[$name]);
+            yield from ($this->checkConstant)($from[$name], $to[$name]);
         }
     }
 }

--- a/src/DetectChanges/BCBreak/ClassBased/ExcludeAnonymousClasses.php
+++ b/src/DetectChanges/BCBreak/ClassBased/ExcludeAnonymousClasses.php
@@ -22,6 +22,6 @@ final class ExcludeAnonymousClasses implements ClassBased
             return Changes::empty();
         }
 
-        return $this->check->__invoke($fromClass, $toClass);
+        return ($this->check)($fromClass, $toClass);
     }
 }

--- a/src/DetectChanges/BCBreak/ClassBased/ExcludeInternalClass.php
+++ b/src/DetectChanges/BCBreak/ClassBased/ExcludeInternalClass.php
@@ -26,7 +26,7 @@ final class ExcludeInternalClass implements ClassBased
             return Changes::empty();
         }
 
-        return $this->check->__invoke($fromClass, $toClass);
+        return ($this->check)($fromClass, $toClass);
     }
 
     private function isInternalDocComment(string $comment): bool

--- a/src/DetectChanges/BCBreak/ClassBased/FinalClassChanged.php
+++ b/src/DetectChanges/BCBreak/ClassBased/FinalClassChanged.php
@@ -22,6 +22,6 @@ final class FinalClassChanged implements ClassBased
             return Changes::empty();
         }
 
-        return $this->checkClass->__invoke($fromClass, $toClass);
+        return ($this->checkClass)($fromClass, $toClass);
     }
 }

--- a/src/DetectChanges/BCBreak/ClassBased/MethodChanged.php
+++ b/src/DetectChanges/BCBreak/ClassBased/MethodChanged.php
@@ -36,7 +36,7 @@ final class MethodChanged implements ClassBased
     private function checkSymbols(array $from, array $to): iterable
     {
         foreach (Vec\keys(Dict\intersect_by_key($from, $to)) as $name) {
-            yield from $this->checkMethod->__invoke($from[$name], $to[$name]);
+            yield from ($this->checkMethod)($from[$name], $to[$name]);
         }
     }
 

--- a/src/DetectChanges/BCBreak/ClassBased/MethodRemoved.php
+++ b/src/DetectChanges/BCBreak/ClassBased/MethodRemoved.php
@@ -36,7 +36,7 @@ final class MethodRemoved implements ClassBased
 
         return Changes::fromList(...Vec\map($removedMethods, function (ReflectionMethod $method): Change {
             return Change::removed(
-                Str\format('Method %s was removed', $this->formatFunction->__invoke($method)),
+                Str\format('Method %s was removed', ($this->formatFunction)($method)),
                 true
             );
         }));

--- a/src/DetectChanges/BCBreak/ClassBased/MultipleChecksOnAClass.php
+++ b/src/DetectChanges/BCBreak/ClassBased/MultipleChecksOnAClass.php
@@ -27,7 +27,7 @@ final class MultipleChecksOnAClass implements ClassBased
     private function multipleChecks(ReflectionClass $fromClass, ReflectionClass $toClass): iterable
     {
         foreach ($this->checks as $check) {
-            yield from $check->__invoke($fromClass, $toClass);
+            yield from $check($fromClass, $toClass);
         }
     }
 }

--- a/src/DetectChanges/BCBreak/ClassBased/OpenClassChanged.php
+++ b/src/DetectChanges/BCBreak/ClassBased/OpenClassChanged.php
@@ -22,6 +22,6 @@ final class OpenClassChanged implements ClassBased
             return Changes::empty();
         }
 
-        return $this->checkClass->__invoke($fromClass, $toClass);
+        return ($this->checkClass)($fromClass, $toClass);
     }
 }

--- a/src/DetectChanges/BCBreak/ClassBased/PropertyChanged.php
+++ b/src/DetectChanges/BCBreak/ClassBased/PropertyChanged.php
@@ -38,7 +38,7 @@ final class PropertyChanged implements ClassBased
     private function checkSymbols(array $from, array $to): iterable
     {
         foreach (Vec\keys(Dict\intersect_by_key($from, $to)) as $name) {
-            yield from $this->checkProperty->__invoke($from[$name], $to[$name]);
+            yield from ($this->checkProperty)($from[$name], $to[$name]);
         }
     }
 }

--- a/src/DetectChanges/BCBreak/ClassBased/PropertyRemoved.php
+++ b/src/DetectChanges/BCBreak/ClassBased/PropertyRemoved.php
@@ -33,7 +33,7 @@ final class PropertyRemoved implements ClassBased
 
         return Changes::fromList(...Vec\map($removedProperties, function (string $property) use ($fromProperties): Change {
             return Change::removed(
-                Str\format('Property %s was removed', $this->formatProperty->__invoke($fromProperties[$property])),
+                Str\format('Property %s was removed', ($this->formatProperty)($fromProperties[$property])),
                 true
             );
         }));

--- a/src/DetectChanges/BCBreak/ClassBased/SkipClassBasedErrors.php
+++ b/src/DetectChanges/BCBreak/ClassBased/SkipClassBasedErrors.php
@@ -21,7 +21,7 @@ final class SkipClassBasedErrors implements ClassBased
     public function __invoke(ReflectionClass $fromClass, ReflectionClass $toClass): Changes
     {
         try {
-            return $this->next->__invoke($fromClass, $toClass);
+            return ($this->next)($fromClass, $toClass);
         } catch (Throwable $failure) {
             return Changes::fromList(Change::skippedDueToFailure($failure));
         }

--- a/src/DetectChanges/BCBreak/ClassConstantBased/MultipleChecksOnAClassConstant.php
+++ b/src/DetectChanges/BCBreak/ClassConstantBased/MultipleChecksOnAClassConstant.php
@@ -27,7 +27,7 @@ final class MultipleChecksOnAClassConstant implements ClassConstantBased
     private function multipleChecks(ReflectionClassConstant $fromConstant, ReflectionClassConstant $toConstant): iterable
     {
         foreach ($this->checks as $check) {
-            yield from $check->__invoke($fromConstant, $toConstant);
+            yield from $check($fromConstant, $toConstant);
         }
     }
 }

--- a/src/DetectChanges/BCBreak/ClassConstantBased/OnlyProtectedClassConstantChanged.php
+++ b/src/DetectChanges/BCBreak/ClassConstantBased/OnlyProtectedClassConstantChanged.php
@@ -22,6 +22,6 @@ final class OnlyProtectedClassConstantChanged implements ClassConstantBased
             return Changes::empty();
         }
 
-        return $this->constantCheck->__invoke($fromConstant, $toConstant);
+        return ($this->constantCheck)($fromConstant, $toConstant);
     }
 }

--- a/src/DetectChanges/BCBreak/ClassConstantBased/OnlyPublicClassConstantChanged.php
+++ b/src/DetectChanges/BCBreak/ClassConstantBased/OnlyPublicClassConstantChanged.php
@@ -22,6 +22,6 @@ final class OnlyPublicClassConstantChanged implements ClassConstantBased
             return Changes::empty();
         }
 
-        return $this->constantCheck->__invoke($fromConstant, $toConstant);
+        return ($this->constantCheck)($fromConstant, $toConstant);
     }
 }

--- a/src/DetectChanges/BCBreak/ClassConstantBased/SkipClassConstantBasedErrors.php
+++ b/src/DetectChanges/BCBreak/ClassConstantBased/SkipClassConstantBasedErrors.php
@@ -21,7 +21,7 @@ final class SkipClassConstantBasedErrors implements ClassConstantBased
     public function __invoke(ReflectionClassConstant $fromConstant, ReflectionClassConstant $toConstant): Changes
     {
         try {
-            return $this->next->__invoke($fromConstant, $toConstant);
+            return ($this->next)($fromConstant, $toConstant);
         } catch (Throwable $failure) {
             return Changes::fromList(Change::skippedDueToFailure($failure));
         }

--- a/src/DetectChanges/BCBreak/FunctionBased/ExcludeInternalFunction.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/ExcludeInternalFunction.php
@@ -26,7 +26,7 @@ final class ExcludeInternalFunction implements FunctionBased
             return Changes::empty();
         }
 
-        return $this->check->__invoke($fromFunction, $toFunction);
+        return ($this->check)($fromFunction, $toFunction);
     }
 
     private function isInternalDocComment(string $comment): bool

--- a/src/DetectChanges/BCBreak/FunctionBased/FunctionBecameInternal.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/FunctionBecameInternal.php
@@ -32,7 +32,7 @@ final class FunctionBecameInternal implements FunctionBased
             return Changes::fromList(Change::changed(
                 Str\format(
                     '%s was marked "@internal"',
-                    $this->formatFunction->__invoke($fromFunction),
+                    ($this->formatFunction)($fromFunction),
                 ),
                 true
             ));

--- a/src/DetectChanges/BCBreak/FunctionBased/MultipleChecksOnAFunction.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/MultipleChecksOnAFunction.php
@@ -27,7 +27,7 @@ final class MultipleChecksOnAFunction implements FunctionBased
     private function multipleChecks(ReflectionFunctionAbstract $fromFunction, ReflectionFunctionAbstract $toFunction): iterable
     {
         foreach ($this->checks as $check) {
-            yield from $check->__invoke($fromFunction, $toFunction);
+            yield from $check($fromFunction, $toFunction);
         }
     }
 }

--- a/src/DetectChanges/BCBreak/FunctionBased/ParameterByReferenceChanged.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/ParameterByReferenceChanged.php
@@ -52,7 +52,7 @@ final class ParameterByReferenceChanged implements FunctionBased
             Str\format(
                 'The parameter $%s of %s changed from %s to %s',
                 $fromParameter->getName(),
-                $this->formatFunction->__invoke($fromParameter->getDeclaringFunction()),
+                ($this->formatFunction)($fromParameter->getDeclaringFunction()),
                 $this->referenceToString($fromByReference),
                 $this->referenceToString($toByReference)
             ),

--- a/src/DetectChanges/BCBreak/FunctionBased/ParameterDefaultValueChanged.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/ParameterDefaultValueChanged.php
@@ -46,7 +46,7 @@ final class ParameterDefaultValueChanged implements FunctionBased
                 Str\format(
                     'Default parameter value for parameter $%s of %s changed from %s to %s',
                     $parameter->getName(),
-                    $this->formatFunction->__invoke($fromFunction),
+                    ($this->formatFunction)($fromFunction),
                     var_export($defaultValueFrom, true),
                     var_export($defaultValueTo, true)
                 ),

--- a/src/DetectChanges/BCBreak/FunctionBased/ParameterTypeChanged.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/ParameterTypeChanged.php
@@ -65,7 +65,7 @@ final class ParameterTypeChanged implements FunctionBased
             Str\format(
                 'The parameter $%s of %s changed from %s to %s',
                 $fromParameter->getName(),
-                $this->formatFunction->__invoke($fromParameter->getDeclaringFunction()),
+                ($this->formatFunction)($fromParameter->getDeclaringFunction()),
                 $fromType,
                 $toType
             ),

--- a/src/DetectChanges/BCBreak/FunctionBased/ParameterTypeContravarianceChanged.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/ParameterTypeContravarianceChanged.php
@@ -48,7 +48,7 @@ final class ParameterTypeContravarianceChanged implements FunctionBased
         $fromType = $fromParameter->getType();
         $toType   = $toParameter->getType();
 
-        if ($this->typeIsContravariant->__invoke($fromType, $toType)) {
+        if (($this->typeIsContravariant)($fromType, $toType)) {
             return Changes::empty();
         }
 
@@ -56,7 +56,7 @@ final class ParameterTypeContravarianceChanged implements FunctionBased
             Str\format(
                 'The parameter $%s of %s changed from %s to a non-contravariant %s',
                 $fromParameter->getName(),
-                $this->formatFunction->__invoke($fromParameter->getDeclaringFunction()),
+                ($this->formatFunction)($fromParameter->getDeclaringFunction()),
                 $this->typeToString($fromType),
                 $this->typeToString($toType)
             ),

--- a/src/DetectChanges/BCBreak/FunctionBased/RequiredParameterAmountIncreased.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/RequiredParameterAmountIncreased.php
@@ -35,7 +35,7 @@ final class RequiredParameterAmountIncreased implements FunctionBased
         return Changes::fromList(Change::changed(
             Str\format(
                 'The number of required arguments for %s increased from %d to %d',
-                $this->formatFunction->__invoke($fromFunction),
+                ($this->formatFunction)($fromFunction),
                 $fromRequiredParameters,
                 $toRequiredParameters
             ),

--- a/src/DetectChanges/BCBreak/FunctionBased/ReturnTypeByReferenceChanged.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/ReturnTypeByReferenceChanged.php
@@ -35,7 +35,7 @@ final class ReturnTypeByReferenceChanged implements FunctionBased
         return Changes::fromList(Change::changed(
             Str\format(
                 'The return value of %s changed from %s to %s',
-                $this->formatFunction->__invoke($fromFunction),
+                ($this->formatFunction)($fromFunction),
                 $this->referenceToString($fromReturnsReference),
                 $this->referenceToString($toReturnsReference)
             ),

--- a/src/DetectChanges/BCBreak/FunctionBased/ReturnTypeChanged.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/ReturnTypeChanged.php
@@ -37,7 +37,7 @@ final class ReturnTypeChanged implements FunctionBased
         return Changes::fromList(Change::changed(
             Str\format(
                 'The return type of %s changed from %s to %s',
-                $this->formatFunction->__invoke($fromFunction),
+                ($this->formatFunction)($fromFunction),
                 $fromReturnType,
                 $toReturnType
             ),

--- a/src/DetectChanges/BCBreak/FunctionBased/ReturnTypeCovarianceChanged.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/ReturnTypeCovarianceChanged.php
@@ -34,14 +34,14 @@ final class ReturnTypeCovarianceChanged implements FunctionBased
         $fromReturnType = $fromFunction->getReturnType();
         $toReturnType   = $toFunction->getReturnType();
 
-        if ($this->typeIsCovariant->__invoke($fromReturnType, $toReturnType)) {
+        if (($this->typeIsCovariant)($fromReturnType, $toReturnType)) {
             return Changes::empty();
         }
 
         return Changes::fromList(Change::changed(
             Str\format(
                 'The return type of %s changed from %s to the non-covariant %s',
-                $this->formatFunction->__invoke($fromFunction),
+                ($this->formatFunction)($fromFunction),
                 $this->typeToString($fromReturnType),
                 $this->typeToString($toReturnType)
             ),

--- a/src/DetectChanges/BCBreak/FunctionBased/SkipFunctionBasedErrors.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/SkipFunctionBasedErrors.php
@@ -21,7 +21,7 @@ final class SkipFunctionBasedErrors implements FunctionBased
     public function __invoke(ReflectionFunctionAbstract $fromFunction, ReflectionFunctionAbstract $toFunction): Changes
     {
         try {
-            return $this->next->__invoke($fromFunction, $toFunction);
+            return ($this->next)($fromFunction, $toFunction);
         } catch (Throwable $failure) {
             return Changes::fromList(Change::skippedDueToFailure($failure));
         }

--- a/src/DetectChanges/BCBreak/InterfaceBased/ExcludeInternalInterface.php
+++ b/src/DetectChanges/BCBreak/InterfaceBased/ExcludeInternalInterface.php
@@ -26,7 +26,7 @@ final class ExcludeInternalInterface implements InterfaceBased
             return Changes::empty();
         }
 
-        return $this->check->__invoke($fromInterface, $toInterface);
+        return ($this->check)($fromInterface, $toInterface);
     }
 
     private function isInternalDocComment(string $comment): bool

--- a/src/DetectChanges/BCBreak/InterfaceBased/MultipleChecksOnAnInterface.php
+++ b/src/DetectChanges/BCBreak/InterfaceBased/MultipleChecksOnAnInterface.php
@@ -27,7 +27,7 @@ final class MultipleChecksOnAnInterface implements InterfaceBased
     private function multipleChecks(ReflectionClass $fromInterface, ReflectionClass $toInterface): iterable
     {
         foreach ($this->checks as $check) {
-            yield from $check->__invoke($fromInterface, $toInterface);
+            yield from $check($fromInterface, $toInterface);
         }
     }
 }

--- a/src/DetectChanges/BCBreak/InterfaceBased/SkipInterfaceBasedErrors.php
+++ b/src/DetectChanges/BCBreak/InterfaceBased/SkipInterfaceBasedErrors.php
@@ -21,7 +21,7 @@ final class SkipInterfaceBasedErrors implements InterfaceBased
     public function __invoke(ReflectionClass $fromInterface, ReflectionClass $toInterface): Changes
     {
         try {
-            return $this->next->__invoke($fromInterface, $toInterface);
+            return ($this->next)($fromInterface, $toInterface);
         } catch (Throwable $failure) {
             return Changes::fromList(Change::skippedDueToFailure($failure));
         }

--- a/src/DetectChanges/BCBreak/InterfaceBased/UseClassBasedChecksOnAnInterface.php
+++ b/src/DetectChanges/BCBreak/InterfaceBased/UseClassBasedChecksOnAnInterface.php
@@ -19,6 +19,6 @@ final class UseClassBasedChecksOnAnInterface implements InterfaceBased
 
     public function __invoke(ReflectionClass $fromInterface, ReflectionClass $toInterface): Changes
     {
-        return $this->check->__invoke($fromInterface, $toInterface);
+        return ($this->check)($fromInterface, $toInterface);
     }
 }

--- a/src/DetectChanges/BCBreak/MethodBased/AccessibleMethodChange.php
+++ b/src/DetectChanges/BCBreak/MethodBased/AccessibleMethodChange.php
@@ -25,6 +25,6 @@ final class AccessibleMethodChange implements MethodBased
             return Changes::empty();
         }
 
-        return $this->check->__invoke($fromMethod, $toMethod);
+        return ($this->check)($fromMethod, $toMethod);
     }
 }

--- a/src/DetectChanges/BCBreak/MethodBased/ExcludeInternalMethod.php
+++ b/src/DetectChanges/BCBreak/MethodBased/ExcludeInternalMethod.php
@@ -26,7 +26,7 @@ final class ExcludeInternalMethod implements MethodBased
             return Changes::empty();
         }
 
-        return $this->check->__invoke($fromMethod, $toMethod);
+        return ($this->check)($fromMethod, $toMethod);
     }
 
     private function isInternalDocComment(string $comment): bool

--- a/src/DetectChanges/BCBreak/MethodBased/MethodFunctionDefinitionChanged.php
+++ b/src/DetectChanges/BCBreak/MethodBased/MethodFunctionDefinitionChanged.php
@@ -22,6 +22,6 @@ final class MethodFunctionDefinitionChanged implements MethodBased
 
     public function __invoke(ReflectionMethod $fromMethod, ReflectionMethod $toMethod): Changes
     {
-        return $this->functionCheck->__invoke($fromMethod, $toMethod);
+        return ($this->functionCheck)($fromMethod, $toMethod);
     }
 }

--- a/src/DetectChanges/BCBreak/MethodBased/MultipleChecksOnAMethod.php
+++ b/src/DetectChanges/BCBreak/MethodBased/MultipleChecksOnAMethod.php
@@ -27,7 +27,7 @@ final class MultipleChecksOnAMethod implements MethodBased
     private function multipleChecks(ReflectionMethod $fromMethod, ReflectionMethod $toMethod): iterable
     {
         foreach ($this->checks as $check) {
-            yield from $check->__invoke($fromMethod, $toMethod);
+            yield from $check($fromMethod, $toMethod);
         }
     }
 }

--- a/src/DetectChanges/BCBreak/MethodBased/OnlyProtectedMethodChanged.php
+++ b/src/DetectChanges/BCBreak/MethodBased/OnlyProtectedMethodChanged.php
@@ -25,6 +25,6 @@ final class OnlyProtectedMethodChanged implements MethodBased
             return Changes::empty();
         }
 
-        return $this->check->__invoke($fromMethod, $toMethod);
+        return ($this->check)($fromMethod, $toMethod);
     }
 }

--- a/src/DetectChanges/BCBreak/MethodBased/OnlyPublicMethodChanged.php
+++ b/src/DetectChanges/BCBreak/MethodBased/OnlyPublicMethodChanged.php
@@ -25,6 +25,6 @@ final class OnlyPublicMethodChanged implements MethodBased
             return Changes::empty();
         }
 
-        return $this->check->__invoke($fromMethod, $toMethod);
+        return ($this->check)($fromMethod, $toMethod);
     }
 }

--- a/src/DetectChanges/BCBreak/MethodBased/SkipMethodBasedErrors.php
+++ b/src/DetectChanges/BCBreak/MethodBased/SkipMethodBasedErrors.php
@@ -21,7 +21,7 @@ final class SkipMethodBasedErrors implements MethodBased
     public function __invoke(ReflectionMethod $fromMethod, ReflectionMethod $toMethod): Changes
     {
         try {
-            return $this->next->__invoke($fromMethod, $toMethod);
+            return ($this->next)($fromMethod, $toMethod);
         } catch (Throwable $failure) {
             return Changes::fromList(Change::skippedDueToFailure($failure));
         }

--- a/src/DetectChanges/BCBreak/PropertyBased/AccessiblePropertyChanged.php
+++ b/src/DetectChanges/BCBreak/PropertyBased/AccessiblePropertyChanged.php
@@ -22,6 +22,6 @@ final class AccessiblePropertyChanged implements PropertyBased
             return Changes::empty();
         }
 
-        return $this->propertyBased->__invoke($fromProperty, $toProperty);
+        return ($this->propertyBased)($fromProperty, $toProperty);
     }
 }

--- a/src/DetectChanges/BCBreak/PropertyBased/ExcludeInternalProperty.php
+++ b/src/DetectChanges/BCBreak/PropertyBased/ExcludeInternalProperty.php
@@ -23,7 +23,7 @@ final class ExcludeInternalProperty implements PropertyBased
             return Changes::empty();
         }
 
-        return $this->propertyBased->__invoke($fromProperty, $toProperty);
+        return ($this->propertyBased)($fromProperty, $toProperty);
     }
 
     private function isInternalDocComment(string $comment): bool

--- a/src/DetectChanges/BCBreak/PropertyBased/MultipleChecksOnAProperty.php
+++ b/src/DetectChanges/BCBreak/PropertyBased/MultipleChecksOnAProperty.php
@@ -27,7 +27,7 @@ final class MultipleChecksOnAProperty implements PropertyBased
     private function multipleChecks(ReflectionProperty $fromProperty, ReflectionProperty $toProperty): iterable
     {
         foreach ($this->checks as $check) {
-            yield from $check->__invoke($fromProperty, $toProperty);
+            yield from $check($fromProperty, $toProperty);
         }
     }
 }

--- a/src/DetectChanges/BCBreak/PropertyBased/OnlyProtectedPropertyChanged.php
+++ b/src/DetectChanges/BCBreak/PropertyBased/OnlyProtectedPropertyChanged.php
@@ -22,6 +22,6 @@ final class OnlyProtectedPropertyChanged implements PropertyBased
             return Changes::empty();
         }
 
-        return $this->propertyBased->__invoke($fromProperty, $toProperty);
+        return ($this->propertyBased)($fromProperty, $toProperty);
     }
 }

--- a/src/DetectChanges/BCBreak/PropertyBased/OnlyPublicPropertyChanged.php
+++ b/src/DetectChanges/BCBreak/PropertyBased/OnlyPublicPropertyChanged.php
@@ -22,6 +22,6 @@ final class OnlyPublicPropertyChanged implements PropertyBased
             return Changes::empty();
         }
 
-        return $this->propertyBased->__invoke($fromProperty, $toProperty);
+        return ($this->propertyBased)($fromProperty, $toProperty);
     }
 }

--- a/src/DetectChanges/BCBreak/PropertyBased/PropertyBecameInternal.php
+++ b/src/DetectChanges/BCBreak/PropertyBased/PropertyBecameInternal.php
@@ -32,7 +32,7 @@ final class PropertyBecameInternal implements PropertyBased
             return Changes::fromList(Change::changed(
                 Str\format(
                     'Property %s was marked "@internal"',
-                    $this->formatProperty->__invoke($fromProperty),
+                    ($this->formatProperty)($fromProperty),
                 ),
                 true
             ));

--- a/src/DetectChanges/BCBreak/PropertyBased/PropertyDefaultValueChanged.php
+++ b/src/DetectChanges/BCBreak/PropertyBased/PropertyDefaultValueChanged.php
@@ -33,7 +33,7 @@ final class PropertyDefaultValueChanged implements PropertyBased
         return Changes::fromList(Change::changed(
             Str\format(
                 'Property %s changed default value from %s to %s',
-                $this->formatProperty->__invoke($fromProperty),
+                ($this->formatProperty)($fromProperty),
                 var_export($fromPropertyDefaultValue, true),
                 var_export($toPropertyDefaultValue, true)
             ),

--- a/src/DetectChanges/BCBreak/PropertyBased/PropertyDocumentedTypeChanged.php
+++ b/src/DetectChanges/BCBreak/PropertyBased/PropertyDocumentedTypeChanged.php
@@ -41,7 +41,7 @@ final class PropertyDocumentedTypeChanged implements PropertyBased
         return Changes::fromList(Change::changed(
             Str\format(
                 'Type documentation for property %s changed from %s to %s',
-                $this->formatProperty->__invoke($fromProperty),
+                ($this->formatProperty)($fromProperty),
                 Str\join($fromTypes, '|') ?: 'having no type',
                 Str\join($toTypes, '|') ?: 'having no type'
             ),

--- a/src/DetectChanges/BCBreak/PropertyBased/PropertyVisibilityReduced.php
+++ b/src/DetectChanges/BCBreak/PropertyBased/PropertyVisibilityReduced.php
@@ -38,7 +38,7 @@ final class PropertyVisibilityReduced implements PropertyBased
         return Changes::fromList(Change::changed(
             Str\format(
                 'Property %s visibility reduced from %s to %s',
-                $this->formatProperty->__invoke($fromProperty),
+                ($this->formatProperty)($fromProperty),
                 $visibilityFrom,
                 $visibilityTo
             ),

--- a/src/DetectChanges/BCBreak/PropertyBased/SkipPropertyBasedErrors.php
+++ b/src/DetectChanges/BCBreak/PropertyBased/SkipPropertyBasedErrors.php
@@ -21,7 +21,7 @@ final class SkipPropertyBasedErrors implements PropertyBased
     public function __invoke(ReflectionProperty $fromProperty, ReflectionProperty $toProperty): Changes
     {
         try {
-            return $this->next->__invoke($fromProperty, $toProperty);
+            return ($this->next)($fromProperty, $toProperty);
         } catch (Throwable $failure) {
             return Changes::fromList(Change::skippedDueToFailure($failure));
         }

--- a/src/DetectChanges/BCBreak/TraitBased/ExcludeInternalTrait.php
+++ b/src/DetectChanges/BCBreak/TraitBased/ExcludeInternalTrait.php
@@ -26,7 +26,7 @@ final class ExcludeInternalTrait implements TraitBased
             return Changes::empty();
         }
 
-        return $this->check->__invoke($fromTrait, $toTrait);
+        return ($this->check)($fromTrait, $toTrait);
     }
 
     private function isInternalDocComment(string $comment): bool

--- a/src/DetectChanges/BCBreak/TraitBased/MultipleChecksOnATrait.php
+++ b/src/DetectChanges/BCBreak/TraitBased/MultipleChecksOnATrait.php
@@ -27,7 +27,7 @@ final class MultipleChecksOnATrait implements TraitBased
     private function multipleChecks(ReflectionClass $fromTrait, ReflectionClass $toTrait): iterable
     {
         foreach ($this->checks as $check) {
-            yield from $check->__invoke($fromTrait, $toTrait);
+            yield from $check($fromTrait, $toTrait);
         }
     }
 }

--- a/src/DetectChanges/BCBreak/TraitBased/SkipTraitBasedErrors.php
+++ b/src/DetectChanges/BCBreak/TraitBased/SkipTraitBasedErrors.php
@@ -21,7 +21,7 @@ final class SkipTraitBasedErrors implements TraitBased
     public function __invoke(ReflectionClass $fromTrait, ReflectionClass $toTrait): Changes
     {
         try {
-            return $this->next->__invoke($fromTrait, $toTrait);
+            return ($this->next)($fromTrait, $toTrait);
         } catch (Throwable $failure) {
             return Changes::fromList(Change::skippedDueToFailure($failure));
         }

--- a/src/DetectChanges/BCBreak/TraitBased/UseClassBasedChecksOnATrait.php
+++ b/src/DetectChanges/BCBreak/TraitBased/UseClassBasedChecksOnATrait.php
@@ -19,6 +19,6 @@ final class UseClassBasedChecksOnATrait implements TraitBased
 
     public function __invoke(ReflectionClass $fromTrait, ReflectionClass $toTrait): Changes
     {
-        return $this->check->__invoke($fromTrait, $toTrait);
+        return ($this->check)($fromTrait, $toTrait);
     }
 }

--- a/src/Factory/ComposerInstallationReflectorFactory.php
+++ b/src/Factory/ComposerInstallationReflectorFactory.php
@@ -31,7 +31,7 @@ final class ComposerInstallationReflectorFactory
     ): ClassReflector {
         return new ClassReflector(
             new MemoizingSourceLocator(new AggregateSourceLocator([
-                $this->locateSources->__invoke($installationDirectory),
+                ($this->locateSources)($installationDirectory),
                 $dependencies,
             ]))
         );

--- a/src/LocateDependencies/LocateDependenciesViaComposer.php
+++ b/src/LocateDependencies/LocateDependenciesViaComposer.php
@@ -55,7 +55,7 @@ final class LocateDependenciesViaComposer implements LocateDependencies
         }, $installationPath);
 
         return new AggregateSourceLocator([
-            (new MakeLocatorForInstalledJson())->__invoke($installationPath, $this->astLocator),
+            (new MakeLocatorForInstalledJson())($installationPath, $this->astLocator),
             new PhpInternalSourceLocator($this->astLocator, new ReflectionSourceStubber()),
         ]);
     }

--- a/src/LocateSources/LocateSourcesViaComposerJson.php
+++ b/src/LocateSources/LocateSourcesViaComposerJson.php
@@ -19,7 +19,6 @@ final class LocateSourcesViaComposerJson implements LocateSources
 
     public function __invoke(string $installationPath): SourceLocator
     {
-        return (new MakeLocatorForComposerJson())
-            ->__invoke($installationPath, $this->astLocator);
+        return (new MakeLocatorForComposerJson())($installationPath, $this->astLocator);
     }
 }

--- a/test/unit/CompareClassesTest.php
+++ b/test/unit/CompareClassesTest.php
@@ -58,9 +58,9 @@ final class CompareClassesTest extends TestCase
 
         Assertion::assertChangesEqual(
             Changes::fromList(Change::changed('class change', true)),
-            $this->compareClasses->__invoke(
-                self::$stringReflectorFactory->__invoke('<?php class A {}'),
-                self::$stringReflectorFactory->__invoke(
+            ($this->compareClasses)(
+                (self::$stringReflectorFactory)('<?php class A {}'),
+                (self::$stringReflectorFactory)(
                     <<<'PHP'
 <?php
 
@@ -71,7 +71,7 @@ class A {
 }
 PHP
                 ),
-                self::$stringReflectorFactory->__invoke(
+                (self::$stringReflectorFactory)(
                     <<<'PHP'
 <?php
 
@@ -94,9 +94,9 @@ PHP
 
         Assertion::assertChangesEqual(
             Changes::fromList(Change::changed('class change', true)),
-            $this->compareClasses->__invoke(
-                self::$stringReflectorFactory->__invoke('<?php class A {}'),
-                self::$stringReflectorFactory->__invoke(
+            ($this->compareClasses)(
+                (self::$stringReflectorFactory)('<?php class A {}'),
+                (self::$stringReflectorFactory)(
                     <<<'PHP'
 <?php
 
@@ -107,7 +107,7 @@ class A {
 }
 PHP
                 ),
-                self::$stringReflectorFactory->__invoke(
+                (self::$stringReflectorFactory)(
                     <<<'PHP'
 <?php
 
@@ -126,10 +126,10 @@ PHP
 
         Assertion::assertChangesEqual(
             Changes::fromList(Change::changed('interface change', true)),
-            $this->compareClasses->__invoke(
-                self::$stringReflectorFactory->__invoke('<?php interface A {}'),
-                self::$stringReflectorFactory->__invoke('<?php interface A {}'),
-                self::$stringReflectorFactory->__invoke('<?php interface A {}')
+            ($this->compareClasses)(
+                (self::$stringReflectorFactory)('<?php interface A {}'),
+                (self::$stringReflectorFactory)('<?php interface A {}'),
+                (self::$stringReflectorFactory)('<?php interface A {}')
             )
         );
     }
@@ -142,10 +142,10 @@ PHP
 
         Assertion::assertChangesEqual(
             Changes::fromList(Change::changed('trait change', true)),
-            $this->compareClasses->__invoke(
-                self::$stringReflectorFactory->__invoke('<?php trait A {}'),
-                self::$stringReflectorFactory->__invoke('<?php trait A {}'),
-                self::$stringReflectorFactory->__invoke('<?php trait A {}')
+            ($this->compareClasses)(
+                (self::$stringReflectorFactory)('<?php trait A {}'),
+                (self::$stringReflectorFactory)('<?php trait A {}'),
+                (self::$stringReflectorFactory)('<?php trait A {}')
             )
         );
     }
@@ -158,10 +158,10 @@ PHP
 
         Assertion::assertChangesEqual(
             Changes::empty(),
-            $this->compareClasses->__invoke(
-                self::$stringReflectorFactory->__invoke('<?php $x = new class () {};'),
-                self::$stringReflectorFactory->__invoke('<?php $x = new class () {};'),
-                self::$stringReflectorFactory->__invoke('<?php $x = new class () {};')
+            ($this->compareClasses)(
+                (self::$stringReflectorFactory)('<?php $x = new class () {};'),
+                (self::$stringReflectorFactory)('<?php $x = new class () {};'),
+                (self::$stringReflectorFactory)('<?php $x = new class () {};')
             )
         );
     }
@@ -172,10 +172,10 @@ PHP
 
         Assertion::assertChangesEqual(
             Changes::empty(),
-            $this->compareClasses->__invoke(
-                self::$stringReflectorFactory->__invoke('<?php '),
-                self::$stringReflectorFactory->__invoke('<?php class A { private function foo() {} }'),
-                self::$stringReflectorFactory->__invoke('<?php ')
+            ($this->compareClasses)(
+                (self::$stringReflectorFactory)('<?php '),
+                (self::$stringReflectorFactory)('<?php class A { private function foo() {} }'),
+                (self::$stringReflectorFactory)('<?php ')
             )
         );
     }
@@ -188,8 +188,8 @@ PHP
 
         Assertion::assertChangesEqual(
             Changes::empty(),
-            $this->compareClasses->__invoke(
-                self::$stringReflectorFactory->__invoke(<<<'PHP'
+            ($this->compareClasses)(
+                (self::$stringReflectorFactory)(<<<'PHP'
 <?php
 
 /** @internal */
@@ -200,8 +200,8 @@ interface B {}
 trait C {}
 PHP
                 ),
-                self::$stringReflectorFactory->__invoke('<?php '),
-                self::$stringReflectorFactory->__invoke('<?php ')
+                (self::$stringReflectorFactory)('<?php '),
+                (self::$stringReflectorFactory)('<?php ')
             )
         );
     }
@@ -214,10 +214,10 @@ PHP
 
         Assertion::assertChangesEqual(
             Changes::fromList(Change::removed('Class A has been deleted', true)),
-            $this->compareClasses->__invoke(
-                self::$stringReflectorFactory->__invoke('<?php class A { private function foo() {} }'),
-                self::$stringReflectorFactory->__invoke('<?php class A { private function foo() {} }'),
-                self::$stringReflectorFactory->__invoke('<?php ')
+            ($this->compareClasses)(
+                (self::$stringReflectorFactory)('<?php class A { private function foo() {} }'),
+                (self::$stringReflectorFactory)('<?php class A { private function foo() {} }'),
+                (self::$stringReflectorFactory)('<?php ')
             )
         );
     }

--- a/test/unit/DetectChanges/BCBreak/ClassBased/AncestorRemovedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/AncestorRemovedTest.php
@@ -32,8 +32,7 @@ final class AncestorRemovedTest extends TestCase
         ReflectionClass $toClass,
         array $expectedMessages
     ): void {
-        $changes = (new AncestorRemoved())
-            ->__invoke($fromClass, $toClass);
+        $changes = (new AncestorRemoved())($fromClass, $toClass);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameAbstractTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameAbstractTest.php
@@ -32,8 +32,7 @@ final class ClassBecameAbstractTest extends TestCase
         ReflectionClass $toClass,
         array $expectedMessages
     ): void {
-        $changes = (new ClassBecameAbstract())
-            ->__invoke($fromClass, $toClass);
+        $changes = (new ClassBecameAbstract())($fromClass, $toClass);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameFinalTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameFinalTest.php
@@ -27,8 +27,7 @@ final class ClassBecameFinalTest extends TestCase
         ReflectionClass $toClass,
         array $expectedMessages
     ): void {
-        $changes = (new ClassBecameFinal())
-            ->__invoke($fromClass, $toClass);
+        $changes = (new ClassBecameFinal())($fromClass, $toClass);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameInterfaceTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameInterfaceTest.php
@@ -29,8 +29,7 @@ final class ClassBecameInterfaceTest extends TestCase
         ReflectionClass $toClass,
         array $expectedMessages
     ): void {
-        $changes = (new ClassBecameInterface())
-            ->__invoke($fromClass, $toClass);
+        $changes = (new ClassBecameInterface())($fromClass, $toClass);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameInternalTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameInternalTest.php
@@ -28,8 +28,7 @@ final class ClassBecameInternalTest extends TestCase
         ReflectionClass $toClass,
         array $expectedMessages
     ): void {
-        $changes = (new ClassBecameInternal())
-            ->__invoke($fromClass, $toClass);
+        $changes = (new ClassBecameInternal())($fromClass, $toClass);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameTraitTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameTraitTest.php
@@ -32,8 +32,7 @@ final class ClassBecameTraitTest extends TestCase
         ReflectionClass $toClass,
         array $expectedMessages
     ): void {
-        $changes = (new ClassBecameTrait())
-            ->__invoke($fromClass, $toClass);
+        $changes = (new ClassBecameTrait())($fromClass, $toClass);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ConstantChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ConstantChangedTest.php
@@ -74,7 +74,7 @@ PHP
                 Change::added('b', true),
                 Change::added('d', true)
             ),
-            (new ConstantChanged($comparator))->__invoke(
+            (new ConstantChanged($comparator))(
                 (new ClassReflector($fromLocator))->reflect('TheClass'),
                 (new ClassReflector($toLocator))->reflect('TheClass')
             )

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ConstantRemovedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ConstantRemovedTest.php
@@ -27,8 +27,7 @@ final class ConstantRemovedTest extends TestCase
         ReflectionClass $toClass,
         array $expectedMessages
     ): void {
-        $changes = (new ConstantRemoved())
-            ->__invoke($fromClass, $toClass);
+        $changes = (new ConstantRemoved())($fromClass, $toClass);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ExcludeAnonymousClassesTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ExcludeAnonymousClassesTest.php
@@ -38,8 +38,7 @@ PHP
             ->with($fromReflection, $toReflection)
             ->willReturn(Changes::empty());
 
-        $excluder = new ExcludeAnonymousClasses($check);
-        $excluder->__invoke($fromReflection, $toReflection);
+        (new ExcludeAnonymousClasses($check))($fromReflection, $toReflection);
     }
 
     public function testAnonymousClassesAreExcluded(): void
@@ -62,7 +61,6 @@ PHP
         $check = $this->createMock(ClassBased::class);
         $check->expects(self::never())->method('__invoke');
 
-        (new ExcludeAnonymousClasses($check))
-            ->__invoke($anonymousClassReflection, $anonymousClassReflection);
+        (new ExcludeAnonymousClasses($check))($anonymousClassReflection, $anonymousClassReflection);
     }
 }

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ExcludeInternalClassTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ExcludeInternalClassTest.php
@@ -39,8 +39,7 @@ PHP
 
         self::assertEquals(
             Changes::fromList(Change::removed('foo', true)),
-            (new ExcludeInternalClass($check))
-                ->__invoke($fromReflection, $toReflection)
+            (new ExcludeInternalClass($check))($fromReflection, $toReflection)
         );
     }
 
@@ -64,8 +63,7 @@ PHP
 
         self::assertEquals(
             Changes::empty(),
-            (new ExcludeInternalClass($check))
-                ->__invoke($reflection, $reflection)
+            (new ExcludeInternalClass($check))($reflection, $reflection)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/ClassBased/FinalClassChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/FinalClassChangedTest.php
@@ -56,7 +56,7 @@ final class FinalClassChangedTest extends TestCase
             ->with($this->fromClass, $this->toClass)
             ->willReturn($changes);
 
-        self::assertEquals($changes, $this->finalClassChanged->__invoke($this->fromClass, $this->toClass));
+        self::assertEquals($changes, ($this->finalClassChanged)($this->fromClass, $this->toClass));
     }
 
     public function testWillNotCheckOpenClass(): void
@@ -71,6 +71,6 @@ final class FinalClassChangedTest extends TestCase
             ->expects(self::never())
             ->method('__invoke');
 
-        self::assertEquals(Changes::empty(), $this->finalClassChanged->__invoke($this->fromClass, $this->toClass));
+        self::assertEquals(Changes::empty(), ($this->finalClassChanged)($this->fromClass, $this->toClass));
     }
 }

--- a/test/unit/DetectChanges/BCBreak/ClassBased/MethodChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/MethodChangedTest.php
@@ -77,7 +77,7 @@ PHP
                 Change::added('d', true),
                 Change::added('G', true)
             ),
-            (new MethodChanged($comparator))->__invoke(
+            (new MethodChanged($comparator))(
                 (new ClassReflector($fromLocator))->reflect('TheClass'),
                 (new ClassReflector($toLocator))->reflect('TheClass')
             )

--- a/test/unit/DetectChanges/BCBreak/ClassBased/MethodRemovedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/MethodRemovedTest.php
@@ -27,8 +27,7 @@ final class MethodRemovedTest extends TestCase
         ReflectionClass $toClass,
         array $expectedMessages
     ): void {
-        $changes = (new MethodRemoved())
-            ->__invoke($fromClass, $toClass);
+        $changes = (new MethodRemoved())($fromClass, $toClass);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/ClassBased/MultipleChecksOnAClassTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/MultipleChecksOnAClassTest.php
@@ -52,7 +52,7 @@ final class MultipleChecksOnAClassTest extends TestCase
                 Change::added('2', true),
                 Change::added('3', true)
             ),
-            $multiCheck->__invoke($from, $to)
+            $multiCheck($from, $to)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/ClassBased/OpenClassChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/OpenClassChangedTest.php
@@ -56,7 +56,7 @@ final class OpenClassChangedTest extends TestCase
             ->with($this->fromClass, $this->toClass)
             ->willReturn($changes);
 
-        self::assertEquals($changes, $this->openClassChanged->__invoke($this->fromClass, $this->toClass));
+        self::assertEquals($changes, ($this->openClassChanged)($this->fromClass, $this->toClass));
     }
 
     public function testWillNotCheckOpenClass(): void
@@ -71,6 +71,6 @@ final class OpenClassChangedTest extends TestCase
             ->expects(self::never())
             ->method('__invoke');
 
-        self::assertEquals(Changes::empty(), $this->openClassChanged->__invoke($this->fromClass, $this->toClass));
+        self::assertEquals(Changes::empty(), ($this->openClassChanged)($this->fromClass, $this->toClass));
     }
 }

--- a/test/unit/DetectChanges/BCBreak/ClassBased/PropertyChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/PropertyChangedTest.php
@@ -74,7 +74,7 @@ PHP
                 Change::added('b', true),
                 Change::added('d', true)
             ),
-            (new PropertyChanged($comparator))->__invoke(
+            (new PropertyChanged($comparator))(
                 (new ClassReflector($fromLocator))->reflect('TheClass'),
                 (new ClassReflector($toLocator))->reflect('TheClass')
             )

--- a/test/unit/DetectChanges/BCBreak/ClassBased/PropertyRemovedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/PropertyRemovedTest.php
@@ -28,8 +28,7 @@ final class PropertyRemovedTest extends TestCase
         ReflectionClass $toClass,
         array $expectedMessages
     ): void {
-        $changes = (new PropertyRemoved())
-            ->__invoke($fromClass, $toClass);
+        $changes = (new PropertyRemoved())($fromClass, $toClass);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/ClassBased/SkipClassBasedErrorsTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/SkipClassBasedErrorsTest.php
@@ -47,7 +47,7 @@ final class SkipClassBasedErrorsTest extends TestCase
             ->with($fromClass, $toClass)
             ->willReturn($expectedChanges);
 
-        self::assertEquals($expectedChanges, $this->check->__invoke($fromClass, $toClass));
+        self::assertEquals($expectedChanges, ($this->check)($fromClass, $toClass));
     }
 
     public function testWillCollectFailures(): void
@@ -65,7 +65,7 @@ final class SkipClassBasedErrorsTest extends TestCase
 
         self::assertEquals(
             Changes::fromList(Change::skippedDueToFailure($exception)),
-            $this->check->__invoke($fromClass, $toClass)
+            ($this->check)($fromClass, $toClass)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/ClassConstantBased/ClassConstantValueChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassConstantBased/ClassConstantValueChangedTest.php
@@ -32,8 +32,7 @@ final class ClassConstantValueChangedTest extends TestCase
         ReflectionClassConstant $toConstant,
         array $expectedMessages
     ): void {
-        $changes = (new ClassConstantValueChanged())
-            ->__invoke($fromConstant, $toConstant);
+        $changes = (new ClassConstantValueChanged())($fromConstant, $toConstant);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/ClassConstantBased/ClassConstantVisibilityReducedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassConstantBased/ClassConstantVisibilityReducedTest.php
@@ -31,8 +31,7 @@ final class ClassConstantVisibilityReducedTest extends TestCase
         ReflectionClassConstant $toConstant,
         array $expectedMessages
     ) : void {
-        $changes = (new ClassConstantVisibilityReduced())
-            ->__invoke($fromConstant, $toConstant);
+        $changes = (new ClassConstantVisibilityReduced())($fromConstant, $toConstant);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/ClassConstantBased/MultipleChecksOnAClassConstantTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassConstantBased/MultipleChecksOnAClassConstantTest.php
@@ -52,7 +52,7 @@ final class MultipleChecksOnAClassConstantTest extends TestCase
                 Change::added('2', true),
                 Change::added('3', true)
             ),
-            $multiCheck->__invoke($from, $to)
+            $multiCheck($from, $to)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/ClassConstantBased/OnlyProtectedClassConstantChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassConstantBased/OnlyProtectedClassConstantChangedTest.php
@@ -54,7 +54,7 @@ final class OnlyProtectedClassConstantChangedTest extends TestCase
 
         self::assertEquals(
             Changes::empty(),
-            $this->changed->__invoke($this->fromConstant, $this->toConstant)
+            ($this->changed)($this->fromConstant, $this->toConstant)
         );
     }
 
@@ -76,7 +76,7 @@ final class OnlyProtectedClassConstantChangedTest extends TestCase
 
         self::assertEquals(
             $changes,
-            $this->changed->__invoke($this->fromConstant, $this->toConstant)
+            ($this->changed)($this->fromConstant, $this->toConstant)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/ClassConstantBased/OnlyPublicClassConstantChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassConstantBased/OnlyPublicClassConstantChangedTest.php
@@ -54,7 +54,7 @@ final class OnlyPublicClassConstantChangedTest extends TestCase
 
         self::assertEquals(
             Changes::empty(),
-            $this->changed->__invoke($this->fromConstant, $this->toConstant)
+            ($this->changed)($this->fromConstant, $this->toConstant)
         );
     }
 
@@ -76,7 +76,7 @@ final class OnlyPublicClassConstantChangedTest extends TestCase
 
         self::assertEquals(
             $changes,
-            $this->changed->__invoke($this->fromConstant, $this->toConstant)
+            ($this->changed)($this->fromConstant, $this->toConstant)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/ClassConstantBased/SkipClassConstantBasedErrorsTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassConstantBased/SkipClassConstantBasedErrorsTest.php
@@ -47,7 +47,7 @@ final class SkipClassConstantBasedErrorsTest extends TestCase
             ->with($fromConstant, $toConstant)
             ->willReturn($expectedChanges);
 
-        self::assertEquals($expectedChanges, $this->check->__invoke($fromConstant, $toConstant));
+        self::assertEquals($expectedChanges, ($this->check)($fromConstant, $toConstant));
     }
 
     public function testWillCollectFailures(): void
@@ -65,7 +65,7 @@ final class SkipClassConstantBasedErrorsTest extends TestCase
 
         self::assertEquals(
             Changes::fromList(Change::skippedDueToFailure($exception)),
-            $this->check->__invoke($fromConstant, $toConstant)
+            ($this->check)($fromConstant, $toConstant)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/ExcludeInternalFunctionTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/ExcludeInternalFunctionTest.php
@@ -39,8 +39,7 @@ PHP
 
         self::assertEquals(
             Changes::fromList(Change::removed('foo', true)),
-            (new ExcludeInternalFunction($check))
-                ->__invoke($function, $function)
+            (new ExcludeInternalFunction($check))($function, $function)
         );
     }
 
@@ -65,8 +64,7 @@ PHP
 
         self::assertEquals(
             Changes::empty(),
-            (new ExcludeInternalFunction($check))
-                ->__invoke($function, $function)
+            (new ExcludeInternalFunction($check))($function, $function)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/FunctionBecameInternalTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/FunctionBecameInternalTest.php
@@ -31,8 +31,7 @@ final class FunctionBecameInternalTest extends TestCase
         ReflectionFunctionAbstract $toFunction,
         array $expectedMessages
     ): void {
-        $changes = (new FunctionBecameInternal())
-            ->__invoke($fromFunction, $toFunction);
+        $changes = (new FunctionBecameInternal())($fromFunction, $toFunction);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/MultipleChecksOnAFunctionTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/MultipleChecksOnAFunctionTest.php
@@ -52,7 +52,7 @@ final class MultipleChecksOnAFunctionTest extends TestCase
                 Change::added('2', true),
                 Change::added('3', true)
             ),
-            $multiCheck->__invoke($from, $to)
+            $multiCheck($from, $to)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterByReferenceChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterByReferenceChangedTest.php
@@ -31,8 +31,7 @@ final class ParameterByReferenceChangedTest extends TestCase
         ReflectionFunctionAbstract $toFunction,
         array $expectedMessages
     ) : void {
-        $changes = (new ParameterByReferenceChanged())
-            ->__invoke($fromFunction, $toFunction);
+        $changes = (new ParameterByReferenceChanged())($fromFunction, $toFunction);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterDefaultValueChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterDefaultValueChangedTest.php
@@ -31,8 +31,7 @@ final class ParameterDefaultValueChangedTest extends TestCase
         ReflectionFunctionAbstract $toFunction,
         array $expectedMessages
     ) : void {
-        $changes = (new ParameterDefaultValueChanged())
-            ->__invoke($fromFunction, $toFunction);
+        $changes = (new ParameterDefaultValueChanged())($fromFunction, $toFunction);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterTypeChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterTypeChangedTest.php
@@ -31,8 +31,7 @@ final class ParameterTypeChangedTest extends TestCase
         ReflectionFunctionAbstract $toFunction,
         array $expectedMessages
     ) : void {
-        $changes = (new ParameterTypeChanged())
-            ->__invoke($fromFunction, $toFunction);
+        $changes = (new ParameterTypeChanged())($fromFunction, $toFunction);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterTypeContravarianceChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterTypeContravarianceChangedTest.php
@@ -32,8 +32,7 @@ final class ParameterTypeContravarianceChangedTest extends TestCase
         ReflectionFunctionAbstract $toFunction,
         array $expectedMessages
     ) : void {
-        $changes = (new ParameterTypeContravarianceChanged(new TypeIsContravariant()))
-            ->__invoke($fromFunction, $toFunction);
+        $changes = (new ParameterTypeContravarianceChanged(new TypeIsContravariant()))($fromFunction, $toFunction);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/RequiredParameterAmountIncreasedTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/RequiredParameterAmountIncreasedTest.php
@@ -31,8 +31,7 @@ final class RequiredParameterAmountIncreasedTest extends TestCase
         ReflectionFunctionAbstract $toFunction,
         array $expectedMessages
     ) : void {
-        $changes = (new RequiredParameterAmountIncreased())
-            ->__invoke($fromFunction, $toFunction);
+        $changes = (new RequiredParameterAmountIncreased())($fromFunction, $toFunction);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/ReturnTypeByReferenceChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/ReturnTypeByReferenceChangedTest.php
@@ -31,8 +31,7 @@ final class ReturnTypeByReferenceChangedTest extends TestCase
         ReflectionFunctionAbstract $toFunction,
         array $expectedMessages
     ) : void {
-        $changes = (new ReturnTypeByReferenceChanged())
-            ->__invoke($fromFunction, $toFunction);
+        $changes = (new ReturnTypeByReferenceChanged())($fromFunction, $toFunction);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/ReturnTypeChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/ReturnTypeChangedTest.php
@@ -31,8 +31,7 @@ final class ReturnTypeChangedTest extends TestCase
         ReflectionFunctionAbstract $toFunction,
         array $expectedMessages
     ) : void {
-        $changes = (new ReturnTypeChanged())
-            ->__invoke($fromFunction, $toFunction);
+        $changes = (new ReturnTypeChanged())($fromFunction, $toFunction);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/ReturnTypeCovarianceChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/ReturnTypeCovarianceChangedTest.php
@@ -32,8 +32,7 @@ final class ReturnTypeCovarianceChangedTest extends TestCase
         ReflectionFunctionAbstract $toFunction,
         array $expectedMessages
     ) : void {
-        $changes = (new ReturnTypeCovarianceChanged(new TypeIsCovariant()))
-            ->__invoke($fromFunction, $toFunction);
+        $changes = (new ReturnTypeCovarianceChanged(new TypeIsCovariant()))($fromFunction, $toFunction);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/SkipFunctionBasedErrorsTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/SkipFunctionBasedErrorsTest.php
@@ -47,7 +47,7 @@ final class SkipFunctionBasedErrorsTest extends TestCase
             ->with($fromFunction, $toFunction)
             ->willReturn($expectedChanges);
 
-        self::assertEquals($expectedChanges, $this->check->__invoke($fromFunction, $toFunction));
+        self::assertEquals($expectedChanges, ($this->check)($fromFunction, $toFunction));
     }
 
     public function testWillCollectFailures(): void
@@ -65,7 +65,7 @@ final class SkipFunctionBasedErrorsTest extends TestCase
 
         self::assertEquals(
             Changes::fromList(Change::skippedDueToFailure($exception)),
-            $this->check->__invoke($fromFunction, $toFunction)
+            ($this->check)($fromFunction, $toFunction)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/InterfaceBased/AncestorRemovedTest.php
+++ b/test/unit/DetectChanges/BCBreak/InterfaceBased/AncestorRemovedTest.php
@@ -32,8 +32,7 @@ final class AncestorRemovedTest extends TestCase
         ReflectionClass $toInterace,
         array $expectedMessages
     ): void {
-        $changes = (new AncestorRemoved())
-            ->__invoke($fromInterface, $toInterace);
+        $changes = (new AncestorRemoved())($fromInterface, $toInterace);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/InterfaceBased/ExcludeInternalInterfaceTest.php
+++ b/test/unit/DetectChanges/BCBreak/InterfaceBased/ExcludeInternalInterfaceTest.php
@@ -38,8 +38,7 @@ PHP
 
         self::assertEquals(
             Changes::fromList(Change::removed('foo', true)),
-            (new ExcludeInternalInterface($check))
-                ->__invoke($reflection, $reflection)
+            (new ExcludeInternalInterface($check))($reflection, $reflection)
         );
     }
 
@@ -63,8 +62,7 @@ PHP
 
         self::assertEquals(
             Changes::empty(),
-            (new ExcludeInternalInterface($check))
-                ->__invoke($reflection, $reflection)
+            (new ExcludeInternalInterface($check))($reflection, $reflection)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/InterfaceBased/InterfaceBecameClassTest.php
+++ b/test/unit/DetectChanges/BCBreak/InterfaceBased/InterfaceBecameClassTest.php
@@ -29,8 +29,7 @@ final class InterfaceBecameClassTest extends TestCase
         ReflectionClass $toClass,
         array $expectedMessages
     ): void {
-        $changes = (new InterfaceBecameClass())
-            ->__invoke($fromClass, $toClass);
+        $changes = (new InterfaceBecameClass())($fromClass, $toClass);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/InterfaceBased/InterfaceBecameTraitTest.php
+++ b/test/unit/DetectChanges/BCBreak/InterfaceBased/InterfaceBecameTraitTest.php
@@ -29,8 +29,7 @@ final class InterfaceBecameTraitTest extends TestCase
         ReflectionClass $toClass,
         array $expectedMessages
     ): void {
-        $changes = (new InterfaceBecameTrait())
-            ->__invoke($fromClass, $toClass);
+        $changes = (new InterfaceBecameTrait())($fromClass, $toClass);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/InterfaceBased/MethodAddedTest.php
+++ b/test/unit/DetectChanges/BCBreak/InterfaceBased/MethodAddedTest.php
@@ -29,8 +29,7 @@ final class MethodAddedTest extends TestCase
         ReflectionClass $toInterface,
         array $expectedMessages
     ): void {
-        $changes = (new MethodAdded())
-            ->__invoke($fromInterface, $toInterface);
+        $changes = (new MethodAdded())($fromInterface, $toInterface);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/InterfaceBased/MultipleChecksOnAnInterfaceTest.php
+++ b/test/unit/DetectChanges/BCBreak/InterfaceBased/MultipleChecksOnAnInterfaceTest.php
@@ -52,7 +52,7 @@ final class MultipleChecksOnAnInterfaceTest extends TestCase
                 Change::added('2', true),
                 Change::added('3', true)
             ),
-            $multiCheck->__invoke($from, $to)
+            $multiCheck($from, $to)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/InterfaceBased/SkipInterfaceBasedErrorsTest.php
+++ b/test/unit/DetectChanges/BCBreak/InterfaceBased/SkipInterfaceBasedErrorsTest.php
@@ -47,7 +47,7 @@ final class SkipInterfaceBasedErrorsTest extends TestCase
             ->with($fromInterface, $toInterface)
             ->willReturn($expectedChanges);
 
-        self::assertEquals($expectedChanges, $this->check->__invoke($fromInterface, $toInterface));
+        self::assertEquals($expectedChanges, ($this->check)($fromInterface, $toInterface));
     }
 
     public function testWillCollectFailures(): void
@@ -65,7 +65,7 @@ final class SkipInterfaceBasedErrorsTest extends TestCase
 
         self::assertEquals(
             Changes::fromList(Change::skippedDueToFailure($exception)),
-            $this->check->__invoke($fromInterface, $toInterface)
+            ($this->check)($fromInterface, $toInterface)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/InterfaceBased/UseClassBasedChecksOnAnInterfaceTest.php
+++ b/test/unit/DetectChanges/BCBreak/InterfaceBased/UseClassBasedChecksOnAnInterfaceTest.php
@@ -34,7 +34,7 @@ final class UseClassBasedChecksOnAnInterfaceTest extends TestCase
 
         self::assertSame(
             $changes,
-            (new UseClassBasedChecksOnAnInterface($classBased))->__invoke($fromInterface, $toInterface)
+            (new UseClassBasedChecksOnAnInterface($classBased))($fromInterface, $toInterface)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/MethodBased/AccessibleMethodChangeTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/AccessibleMethodChangeTest.php
@@ -46,7 +46,7 @@ final class AccessibleMethodChangeTest extends TestCase
             ->expects(self::never())
             ->method('__invoke');
 
-        self::assertEquals(Changes::empty(), $this->methodCheck->__invoke($from, $to));
+        self::assertEquals(Changes::empty(), ($this->methodCheck)($from, $to));
     }
 
     public function testWillCheckVisibleMethods(): void
@@ -66,6 +66,6 @@ final class AccessibleMethodChangeTest extends TestCase
             ->with($from, $to)
             ->willReturn($result);
 
-        self::assertEquals($result, $this->methodCheck->__invoke($from, $to));
+        self::assertEquals($result, ($this->methodCheck)($from, $to));
     }
 }

--- a/test/unit/DetectChanges/BCBreak/MethodBased/ExcludeInternalMethodTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/ExcludeInternalMethodTest.php
@@ -40,8 +40,7 @@ PHP
 
         self::assertEquals(
             Changes::fromList(Change::removed('foo', true)),
-            (new ExcludeInternalMethod($check))
-                ->__invoke($method, $method)
+            (new ExcludeInternalMethod($check))($method, $method)
         );
     }
 
@@ -68,8 +67,7 @@ PHP
 
         self::assertEquals(
             Changes::empty(),
-            (new ExcludeInternalMethod($check))
-                ->__invoke($method, $method)
+            (new ExcludeInternalMethod($check))($method, $method)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/MethodBased/MethodBecameFinalTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/MethodBecameFinalTest.php
@@ -32,8 +32,7 @@ final class MethodBecameFinalTest extends TestCase
         ReflectionMethod $toMethod,
         array $expectedMessages
     ): void {
-        $changes = (new MethodBecameFinal())
-            ->__invoke($fromMethod, $toMethod);
+        $changes = (new MethodBecameFinal())($fromMethod, $toMethod);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/MethodBased/MethodConcretenessChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/MethodConcretenessChangedTest.php
@@ -32,8 +32,7 @@ final class MethodConcretenessChangedTest extends TestCase
         ReflectionMethod $toMethod,
         array $expectedMessages
     ): void {
-        $changes = (new MethodConcretenessChanged())
-            ->__invoke($fromMethod, $toMethod);
+        $changes = (new MethodConcretenessChanged())($fromMethod, $toMethod);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/MethodBased/MethodFunctionDefinitionChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/MethodFunctionDefinitionChangedTest.php
@@ -46,6 +46,6 @@ final class MethodFunctionDefinitionChangedTest extends TestCase
             ->with($from, $to)
             ->willReturn($result);
 
-        self::assertEquals($result, $this->methodCheck->__invoke($from, $to));
+        self::assertEquals($result, ($this->methodCheck)($from, $to));
     }
 }

--- a/test/unit/DetectChanges/BCBreak/MethodBased/MethodScopeChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/MethodScopeChangedTest.php
@@ -32,8 +32,7 @@ final class MethodScopeChangedTest extends TestCase
         ReflectionMethod $toMethod,
         array $expectedMessages
     ): void {
-        $changes = (new MethodScopeChanged())
-            ->__invoke($fromMethod, $toMethod);
+        $changes = (new MethodScopeChanged())($fromMethod, $toMethod);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/MethodBased/MethodVisibilityReducedTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/MethodVisibilityReducedTest.php
@@ -32,8 +32,7 @@ final class MethodVisibilityReducedTest extends TestCase
         ReflectionMethod $toMethod,
         array $expectedMessages
     ): void {
-        $changes = (new MethodVisibilityReduced())
-            ->__invoke($fromMethod, $toMethod);
+        $changes = (new MethodVisibilityReduced())($fromMethod, $toMethod);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/MethodBased/MultipleChecksOnAMethodTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/MultipleChecksOnAMethodTest.php
@@ -52,7 +52,7 @@ final class MultipleChecksOnAMethodTest extends TestCase
                 Change::added('2', true),
                 Change::added('3', true)
             ),
-            $multiCheck->__invoke($from, $to)
+            $multiCheck($from, $to)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/MethodBased/OnlyProtectedMethodChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/OnlyProtectedMethodChangedTest.php
@@ -46,7 +46,7 @@ final class OnlyProtectedMethodChangedTest extends TestCase
             ->expects(self::never())
             ->method('__invoke');
 
-        self::assertEquals(Changes::empty(), $this->methodCheck->__invoke($from, $to));
+        self::assertEquals(Changes::empty(), ($this->methodCheck)($from, $to));
     }
 
     public function testWillCheckProtectedMethods(): void
@@ -66,6 +66,6 @@ final class OnlyProtectedMethodChangedTest extends TestCase
             ->with($from, $to)
             ->willReturn($result);
 
-        self::assertEquals($result, $this->methodCheck->__invoke($from, $to));
+        self::assertEquals($result, ($this->methodCheck)($from, $to));
     }
 }

--- a/test/unit/DetectChanges/BCBreak/MethodBased/OnlyPublicMethodChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/OnlyPublicMethodChangedTest.php
@@ -46,7 +46,7 @@ final class OnlyPublicMethodChangedTest extends TestCase
             ->expects(self::never())
             ->method('__invoke');
 
-        self::assertEquals(Changes::empty(), $this->methodCheck->__invoke($from, $to));
+        self::assertEquals(Changes::empty(), ($this->methodCheck)($from, $to));
     }
 
     public function testWillCheckPublicMethods(): void
@@ -66,6 +66,6 @@ final class OnlyPublicMethodChangedTest extends TestCase
             ->with($from, $to)
             ->willReturn($result);
 
-        self::assertEquals($result, $this->methodCheck->__invoke($from, $to));
+        self::assertEquals($result, ($this->methodCheck)($from, $to));
     }
 }

--- a/test/unit/DetectChanges/BCBreak/MethodBased/SkipMethodBasedErrorsTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/SkipMethodBasedErrorsTest.php
@@ -47,7 +47,7 @@ final class SkipMethodBasedErrorsTest extends TestCase
             ->with($fromMethod, $toMethod)
             ->willReturn($expectedChanges);
 
-        self::assertEquals($expectedChanges, $this->check->__invoke($fromMethod, $toMethod));
+        self::assertEquals($expectedChanges, ($this->check)($fromMethod, $toMethod));
     }
 
     public function testWillCollectFailures(): void
@@ -65,7 +65,7 @@ final class SkipMethodBasedErrorsTest extends TestCase
 
         self::assertEquals(
             Changes::fromList(Change::skippedDueToFailure($exception)),
-            $this->check->__invoke($fromMethod, $toMethod)
+            ($this->check)($fromMethod, $toMethod)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/AccessiblePropertyChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/AccessiblePropertyChangedTest.php
@@ -54,7 +54,7 @@ final class AccessiblePropertyChangedTest extends TestCase
 
         self::assertEquals(
             Changes::empty(),
-            $this->accessiblePropertyChanged->__invoke($this->fromProperty, $this->toProperty)
+            ($this->accessiblePropertyChanged)($this->fromProperty, $this->toProperty)
         );
     }
 
@@ -76,7 +76,7 @@ final class AccessiblePropertyChangedTest extends TestCase
 
         self::assertEquals(
             $changes,
-            $this->accessiblePropertyChanged->__invoke($this->fromProperty, $this->toProperty)
+            ($this->accessiblePropertyChanged)($this->fromProperty, $this->toProperty)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/ExcludeInternalPropertyTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/ExcludeInternalPropertyTest.php
@@ -42,8 +42,7 @@ PHP
 
         self::assertEquals(
             Changes::fromList(Change::removed('foo', true)),
-            (new ExcludeInternalProperty($check))
-                ->__invoke($property, $property)
+            (new ExcludeInternalProperty($check))($property, $property)
         );
     }
 
@@ -72,8 +71,7 @@ PHP
 
         self::assertEquals(
             Changes::empty(),
-            (new ExcludeInternalProperty($check))
-                ->__invoke($property, $property)
+            (new ExcludeInternalProperty($check))($property, $property)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/MultipleChecksOnAPropertyTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/MultipleChecksOnAPropertyTest.php
@@ -52,7 +52,7 @@ final class MultipleChecksOnAPropertyTest extends TestCase
                 Change::added('2', true),
                 Change::added('3', true)
             ),
-            $multiCheck->__invoke($from, $to)
+            $multiCheck($from, $to)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/OnlyProtectedPropertyChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/OnlyProtectedPropertyChangedTest.php
@@ -54,7 +54,7 @@ final class OnlyProtectedPropertyChangedTest extends TestCase
 
         self::assertEquals(
             Changes::empty(),
-            $this->changed->__invoke($this->fromProperty, $this->toProperty)
+            ($this->changed)($this->fromProperty, $this->toProperty)
         );
     }
 
@@ -76,7 +76,7 @@ final class OnlyProtectedPropertyChangedTest extends TestCase
 
         self::assertEquals(
             $changes,
-            $this->changed->__invoke($this->fromProperty, $this->toProperty)
+            ($this->changed)($this->fromProperty, $this->toProperty)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/OnlyPublicPropertyChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/OnlyPublicPropertyChangedTest.php
@@ -54,7 +54,7 @@ final class OnlyPublicPropertyChangedTest extends TestCase
 
         self::assertEquals(
             Changes::empty(),
-            $this->changed->__invoke($this->fromProperty, $this->toProperty)
+            ($this->changed)($this->fromProperty, $this->toProperty)
         );
     }
 
@@ -76,7 +76,7 @@ final class OnlyPublicPropertyChangedTest extends TestCase
 
         self::assertEquals(
             $changes,
-            $this->changed->__invoke($this->fromProperty, $this->toProperty)
+            ($this->changed)($this->fromProperty, $this->toProperty)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyBecameInternalTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyBecameInternalTest.php
@@ -33,8 +33,7 @@ final class PropertyBecameInternalTest extends TestCase
         ReflectionProperty $toFunction,
         array $expectedMessages
     ): void {
-        $changes = (new PropertyBecameInternal())
-            ->__invoke($fromFunction, $toFunction);
+        $changes = (new PropertyBecameInternal())($fromFunction, $toFunction);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyDefaultValueChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyDefaultValueChangedTest.php
@@ -33,8 +33,7 @@ final class PropertyDefaultValueChangedTest extends TestCase
         ReflectionProperty $toFunction,
         array $expectedMessages
     ): void {
-        $changes = (new PropertyDefaultValueChanged())
-            ->__invoke($fromFunction, $toFunction);
+        $changes = (new PropertyDefaultValueChanged())($fromFunction, $toFunction);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyDocumentedTypeChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyDocumentedTypeChangedTest.php
@@ -33,8 +33,7 @@ final class PropertyDocumentedTypeChangedTest extends TestCase
         ReflectionProperty $toProperty,
         array $expectedMessages
     ): void {
-        $changes = (new PropertyDocumentedTypeChanged())
-            ->__invoke($fromProperty, $toProperty);
+        $changes = (new PropertyDocumentedTypeChanged())($fromProperty, $toProperty);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyScopeChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyScopeChangedTest.php
@@ -33,8 +33,7 @@ final class PropertyScopeChangedTest extends TestCase
         ReflectionProperty $toFunction,
         array $expectedMessages
     ): void {
-        $changes = (new PropertyScopeChanged())
-            ->__invoke($fromFunction, $toFunction);
+        $changes = (new PropertyScopeChanged())($fromFunction, $toFunction);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyVisibilityReducedTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyVisibilityReducedTest.php
@@ -33,8 +33,7 @@ final class PropertyVisibilityReducedTest extends TestCase
         ReflectionProperty $toProperty,
         array $expectedMessages
     ): void {
-        $changes = (new PropertyVisibilityReduced())
-            ->__invoke($fromProperty, $toProperty);
+        $changes = (new PropertyVisibilityReduced())($fromProperty, $toProperty);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/SkipPropertyBasedErrorsTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/SkipPropertyBasedErrorsTest.php
@@ -47,7 +47,7 @@ final class SkipPropertyBasedErrorsTest extends TestCase
             ->with($fromProperty, $toProperty)
             ->willReturn($expectedChanges);
 
-        self::assertEquals($expectedChanges, $this->check->__invoke($fromProperty, $toProperty));
+        self::assertEquals($expectedChanges, ($this->check)($fromProperty, $toProperty));
     }
 
     public function testWillCollectFailures(): void
@@ -65,7 +65,7 @@ final class SkipPropertyBasedErrorsTest extends TestCase
 
         self::assertEquals(
             Changes::fromList(Change::skippedDueToFailure($exception)),
-            $this->check->__invoke($fromProperty, $toProperty)
+            ($this->check)($fromProperty, $toProperty)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/TraitBased/ExcludeInternalTraitTest.php
+++ b/test/unit/DetectChanges/BCBreak/TraitBased/ExcludeInternalTraitTest.php
@@ -38,8 +38,7 @@ PHP
 
         self::assertEquals(
             Changes::fromList(Change::removed('foo', true)),
-            (new ExcludeInternalTrait($check))
-                ->__invoke($reflection, $reflection)
+            (new ExcludeInternalTrait($check))($reflection, $reflection)
         );
     }
 
@@ -63,8 +62,7 @@ PHP
 
         self::assertEquals(
             Changes::empty(),
-            (new ExcludeInternalTrait($check))
-                ->__invoke($reflection, $reflection)
+            (new ExcludeInternalTrait($check))($reflection, $reflection)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/TraitBased/MultipleChecksOnATraitTest.php
+++ b/test/unit/DetectChanges/BCBreak/TraitBased/MultipleChecksOnATraitTest.php
@@ -52,7 +52,7 @@ final class MultipleChecksOnATraitTest extends TestCase
                 Change::added('2', true),
                 Change::added('3', true)
             ),
-            $multiCheck->__invoke($from, $to)
+            $multiCheck($from, $to)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/TraitBased/SkipTraitBasedErrorsTest.php
+++ b/test/unit/DetectChanges/BCBreak/TraitBased/SkipTraitBasedErrorsTest.php
@@ -47,7 +47,7 @@ final class SkipTraitBasedErrorsTest extends TestCase
             ->with($fromTrait, $toTrait)
             ->willReturn($expectedChanges);
 
-        self::assertEquals($expectedChanges, $this->check->__invoke($fromTrait, $toTrait));
+        self::assertEquals($expectedChanges, ($this->check)($fromTrait, $toTrait));
     }
 
     public function testWillCollectFailures(): void
@@ -65,7 +65,7 @@ final class SkipTraitBasedErrorsTest extends TestCase
 
         self::assertEquals(
             Changes::fromList(Change::skippedDueToFailure($exception)),
-            $this->check->__invoke($fromTrait, $toTrait)
+            ($this->check)($fromTrait, $toTrait)
         );
     }
 }

--- a/test/unit/DetectChanges/BCBreak/TraitBased/TraitBecameClassTest.php
+++ b/test/unit/DetectChanges/BCBreak/TraitBased/TraitBecameClassTest.php
@@ -32,8 +32,7 @@ final class TraitBecameClassTest extends TestCase
         ReflectionClass $toClass,
         array $expectedMessages
     ): void {
-        $changes = (new TraitBecameClass())
-            ->__invoke($fromClass, $toClass);
+        $changes = (new TraitBecameClass())($fromClass, $toClass);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/TraitBased/TraitBecameInterfaceTest.php
+++ b/test/unit/DetectChanges/BCBreak/TraitBased/TraitBecameInterfaceTest.php
@@ -32,8 +32,7 @@ final class TraitBecameInterfaceTest extends TestCase
         ReflectionClass $toClass,
         array $expectedMessages
     ): void {
-        $changes = (new TraitBecameInterface())
-            ->__invoke($fromClass, $toClass);
+        $changes = (new TraitBecameInterface())($fromClass, $toClass);
 
         self::assertSame(
             $expectedMessages,

--- a/test/unit/DetectChanges/BCBreak/TraitBased/UseClassBasedChecksOnATraitTest.php
+++ b/test/unit/DetectChanges/BCBreak/TraitBased/UseClassBasedChecksOnATraitTest.php
@@ -32,6 +32,6 @@ final class UseClassBasedChecksOnATraitTest extends TestCase
             ->with($fromTrait, $toTrait)
             ->willReturn($changes);
 
-        self::assertSame($changes, (new UseClassBasedChecksOnATrait($classBased))->__invoke($fromTrait, $toTrait));
+        self::assertSame($changes, (new UseClassBasedChecksOnATrait($classBased))($fromTrait, $toTrait));
     }
 }

--- a/test/unit/DetectChanges/Variance/TypeIsContravariantTest.php
+++ b/test/unit/DetectChanges/Variance/TypeIsContravariantTest.php
@@ -26,8 +26,7 @@ final class TypeIsContravariantTest extends TestCase
     ): void {
         self::assertSame(
             $expectedToBeContravariant,
-            (new TypeIsContravariant())
-                ->__invoke($type, $newType)
+            (new TypeIsContravariant())($type, $newType)
         );
     }
 
@@ -210,8 +209,7 @@ PHP
     public function testContravarianceConsidersSameTypeAlwaysContravariant(?ReflectionType $type): void
     {
         self::assertTrue(
-            (new TypeIsContravariant())
-                ->__invoke($type, $type)
+            (new TypeIsContravariant())($type, $type)
         );
     }
 
@@ -273,8 +271,8 @@ PHP
 
         $isContravariant = new TypeIsContravariant();
 
-        self::assertFalse($isContravariant->__invoke($nullable, $notNullable));
-        self::assertTrue($isContravariant->__invoke($notNullable, $nullable));
+        self::assertFalse($isContravariant($nullable, $notNullable));
+        self::assertTrue($isContravariant($notNullable, $nullable));
     }
 
     /** @return string[][] */

--- a/test/unit/DetectChanges/Variance/TypeIsCovariantTest.php
+++ b/test/unit/DetectChanges/Variance/TypeIsCovariantTest.php
@@ -26,8 +26,7 @@ final class TypeIsCovariantTest extends TestCase
     ): void {
         self::assertSame(
             $expectedToBeContravariant,
-            (new TypeIsCovariant())
-                ->__invoke($type, $newType)
+            (new TypeIsCovariant())($type, $newType)
         );
     }
 
@@ -221,8 +220,7 @@ PHP
     public function testCovarianceConsidersSameTypeAlwaysCovariant(?ReflectionType $type): void
     {
         self::assertTrue(
-            (new TypeIsCovariant())
-                ->__invoke($type, $type)
+            (new TypeIsCovariant())($type, $type)
         );
     }
 
@@ -284,8 +282,8 @@ PHP
 
         $isCovariant = new TypeIsCovariant();
 
-        self::assertTrue($isCovariant->__invoke($nullable, $notNullable));
-        self::assertFalse($isCovariant->__invoke($notNullable, $nullable));
+        self::assertTrue($isCovariant($nullable, $notNullable));
+        self::assertFalse($isCovariant($notNullable, $nullable));
     }
 
     /** @return string[][] */

--- a/test/unit/Factory/ComposerInstallationReflectorFactoryTest.php
+++ b/test/unit/Factory/ComposerInstallationReflectorFactoryTest.php
@@ -45,8 +45,10 @@ PHP
 
         self::assertSame(
             '/** an example */',
-            (new ComposerInstallationReflectorFactory($locateSources))
-                ->__invoke($path, $this->createMock(SourceLocator::class))
+            (new ComposerInstallationReflectorFactory($locateSources))(
+                $path,
+                $this->createMock(SourceLocator::class)
+            )
                 ->reflect('Dummy')
                 ->getDocComment()
         );

--- a/test/unit/Formatter/ReflectionFunctionAbstractNameTest.php
+++ b/test/unit/Formatter/ReflectionFunctionAbstractNameTest.php
@@ -22,7 +22,7 @@ final class ReflectionFunctionAbstractNameTest extends TestCase
      */
     public function testName(ReflectionFunctionAbstract $function, string $expectedName) : void
     {
-        self::assertSame($expectedName, (new ReflectionFunctionAbstractName())->__invoke($function));
+        self::assertSame($expectedName, (new ReflectionFunctionAbstractName())($function));
     }
 
     /**

--- a/test/unit/Formatter/ReflectionPropertyNameTest.php
+++ b/test/unit/Formatter/ReflectionPropertyNameTest.php
@@ -25,7 +25,7 @@ final class ReflectionPropertyNameTest extends TestCase
      */
     public function testName(ReflectionProperty $property, string $expectedName): void
     {
-        self::assertSame($expectedName, (new ReflectionPropertyName())->__invoke($property));
+        self::assertSame($expectedName, (new ReflectionPropertyName())($property));
     }
 
     /**

--- a/test/unit/LocateDependencies/LocateDependenciesViaComposerTest.php
+++ b/test/unit/LocateDependencies/LocateDependenciesViaComposerTest.php
@@ -66,9 +66,7 @@ final class LocateDependenciesViaComposerTest extends TestCase
         $this->expectException(InvariantViolationException::class);
         $this->expectExceptionMessage('Could not locate composer.json within installation path.');
 
-        $this
-            ->locateDependencies
-            ->__invoke(__DIR__ . '/non-existing', false);
+        ($this->locateDependencies)(__DIR__ . '/non-existing', false);
     }
 
     public function testWillLocateDependencies(): void
@@ -105,9 +103,7 @@ final class LocateDependenciesViaComposerTest extends TestCase
                 self::assertSame($this->expectedInstallationPath, Env\current_dir());
             });
 
-        $locator = $this
-            ->locateDependencies
-            ->__invoke($this->expectedInstallationPath, false);
+        $locator = ($this->locateDependencies)($this->expectedInstallationPath, false);
 
         self::assertInstanceOf(AggregateSourceLocator::class, $locator);
 
@@ -158,9 +154,7 @@ final class LocateDependenciesViaComposerTest extends TestCase
                 self::assertSame($this->expectedInstallationPath, Env\current_dir());
             });
 
-        $locator = $this
-            ->locateDependencies
-            ->__invoke($this->expectedInstallationPath, true);
+        $locator = ($this->locateDependencies)($this->expectedInstallationPath, true);
 
         self::assertInstanceOf(AggregateSourceLocator::class, $locator);
 

--- a/test/unit/LocateSources/LocateSourcesViaComposerJsonTest.php
+++ b/test/unit/LocateSources/LocateSourcesViaComposerJsonTest.php
@@ -26,8 +26,7 @@ final class LocateSourcesViaComposerJsonTest extends TestCase
     public function testCanLocateClassInMappendAutoloadDefinitions(): void
     {
         $reflector = new ClassReflector(
-            $this->locateSources
-                ->__invoke(__DIR__ . '/../../asset/located-sources/composer-definition-with-everything')
+            ($this->locateSources)(__DIR__ . '/../../asset/located-sources/composer-definition-with-everything')
         );
 
         self::assertSame(


### PR DESCRIPTION
Fixes #59 (is a rebased version of that PR) 