### PR TITLE
Add testsand implementation for property types changing from docblock-only to native type

### DIFF
--- a/src/DetectChanges/BCBreak/PropertyBased/PropertyDocumentedTypeChanged.php
+++ b/src/DetectChanges/BCBreak/PropertyBased/PropertyDocumentedTypeChanged.php
@@ -11,6 +11,8 @@ use Roave\BackwardCompatibility\Changes;
 use Roave\BackwardCompatibility\Formatter\ReflectionPropertyName;
 use Roave\BetterReflection\Reflection\ReflectionProperty;
 
+use function array_merge;
+
 /**
  * Type declarations for properties are invariant: you can't restrict the type because the consumer may
  * write invalid values to it, and you cannot widen the type because the consumer may expect a specific
@@ -27,12 +29,18 @@ final class PropertyDocumentedTypeChanged implements PropertyBased
 
     public function __invoke(ReflectionProperty $fromProperty, ReflectionProperty $toProperty): Changes
     {
+        $toNativeType = [];
+        $toType       = $toProperty->getType();
+        if ($toType !== null) {
+            $toNativeType[] = $toType->getName();
+        }
+
         if ($fromProperty->getDocComment() === '') {
             return Changes::empty();
         }
 
         $fromTypes = Vec\sort($fromProperty->getDocBlockTypeStrings());
-        $toTypes   = Vec\sort($toProperty->getDocBlockTypeStrings());
+        $toTypes   = Vec\sort(array_merge($toNativeType, $toProperty->getDocBlockTypeStrings()));
 
         if ($fromTypes === $toTypes) {
             return Changes::empty();

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyDocumentedTypeChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyDocumentedTypeChangedTest.php
@@ -222,7 +222,7 @@ PHP
             'propertyTypeBeingDuplicatedAreNotBcBreaks'                         => [],
             'propertyWithComplexDocblockThatCannotBeParsed'                     => [],
             'propertyWithDocblockTypeHintChangeToNativeTypeHint'                => [],
-            'propertyWithDocblockTypeHintChangeToNativeTypeHintAndTypeChange'   => ['[BC] CHANGED: Type documentation for property TheClass#propertyWithDocblockTypeHintChangeToNativeTypeHintAndTypeChange changed from int to float'],
+            'propertyWithDocblockTypeHintChangeToNativeTypeHintAndTypeChange'   => ['[BC] CHANGED: Type documentation for property TheClass#$propertyWithDocblockTypeHintChangeToNativeTypeHintAndTypeChange changed from int to float'],
         ];
 
         return array_combine(

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyDocumentedTypeChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyDocumentedTypeChangedTest.php
@@ -119,7 +119,10 @@ class TheClass {
      */
     public $propertyWithDocblockTypeHintChangeToNativeTypeHint;
     
-    public int $propertyWithNativeTypeHintChanged;
+    /**
+     * @var int
+     */
+    public $propertyWithDocblockTypeHintChangeToNativeTypeHintAndTypeChange;
 }
 PHP
             ,
@@ -192,7 +195,7 @@ class TheClass {
     
     public int $propertyWithDocblockTypeHintChangeToNativeTypeHint;
  
-    public float $propertyWithNativeTypeHintChanged;
+    public float $propertyWithDocblockTypeHintChangeToNativeTypeHintAndTypeChange;
 }
 PHP
             ,
@@ -219,7 +222,7 @@ PHP
             'propertyTypeBeingDuplicatedAreNotBcBreaks'                         => [],
             'propertyWithComplexDocblockThatCannotBeParsed'                     => [],
             'propertyWithDocblockTypeHintChangeToNativeTypeHint'                => [],
-            'propertyWithNativeTypeHintChanged'                                 => ['[BC] CHANGED: Type documentation for property TheClass#propertyWithNativeTypeHintChanged changed from int to float'],
+            'propertyWithDocblockTypeHintChangeToNativeTypeHintAndTypeChange'   => ['[BC] CHANGED: Type documentation for property TheClass#propertyWithDocblockTypeHintChangeToNativeTypeHintAndTypeChange changed from int to float'],
         ];
 
         return array_combine(

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyDocumentedTypeChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyDocumentedTypeChangedTest.php
@@ -113,6 +113,13 @@ class TheClass {
      * @var GenericType<T1, T2>
      */ 
     public $propertyWithComplexDocblockThatCannotBeParsed;
+    
+    /**
+     * @var int
+     */
+    public $propertyWithDocblockTypeHintChangeToNativeTypeHint;
+    
+    public int $propertyWithNativeTypeHintChanged;
 }
 PHP
             ,
@@ -182,6 +189,10 @@ class TheClass {
      * @var GenericType<T1, T2>
      */ 
     public $propertyWithComplexDocblockThatCannotBeParsed;
+    
+    public int $propertyWithDocblockTypeHintChangeToNativeTypeHint;
+ 
+    public float $propertyWithNativeTypeHintChanged;
 }
 PHP
             ,
@@ -207,6 +218,8 @@ PHP
             'duplicatePropertyTypesBeingDeduplicatedAreNotBcBreaks'             => [],
             'propertyTypeBeingDuplicatedAreNotBcBreaks'                         => [],
             'propertyWithComplexDocblockThatCannotBeParsed'                     => [],
+            'propertyWithDocblockTypeHintChangeToNativeTypeHint'                => [],
+            'propertyWithNativeTypeHintChanged'                                 => ['[BC] CHANGED: Type documentation for property TheClass#propertyWithNativeTypeHintChanged changed from int to float'],
         ];
 
         return array_combine(


### PR DESCRIPTION
As see yesterday, native property types aren't supported currently. 
https://twitter.com/tomasnorre/status/1464301968264994816

I have now added tests that proves this. I'm still trying to get my head around how to implement the change, I'm not really strong at AST, even though I have written some Rector rules. 

Any pointers on how to approach this would be helpful, thanks.