### PR TITLE
#342 implemented GitHub Actions output format

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -83,7 +83,7 @@ jobs:
         run: "composer install --no-interaction --no-progress --no-suggest"
 
       - name: "Roave Backward Compatibility Check"
-        run: "bin/roave-backward-compatibility-check"
+        run: "bin/roave-backward-compatibility-check --format=github-actions"
 
   check-composer-dependencies:
     name: "Composer Require Checker"

--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ To generate additional documentation for changelogs:
 vendor/bin/roave-backward-compatibility-check --format=markdown > results.md
 ```
 
+### GitHub Actions
+
+When running in GitHub Actions, it is endorsed to use the `--format=github-actions` output format:
+
+```bash
+vendor/bin/roave-backward-compatibility-check --format=github-actions
+```
+
 ### Documentation
 
 If you need further guidance:

--- a/src/Change.php
+++ b/src/Change.php
@@ -15,19 +15,15 @@ final class Change
     private const REMOVED = 'removed';
     private const SKIPPED = 'skipped';
 
-    /** @psalm-var self::* */
-    private string $modificationType;
-
-    private string $description;
-
-    private bool $isBcBreak;
-
     /** @psalm-param self::* $modificationType */
-    private function __construct(string $modificationType, string $description, bool $isBcBreak)
-    {
-        $this->modificationType = $modificationType;
-        $this->description      = $description;
-        $this->isBcBreak        = $isBcBreak;
+    private function __construct(
+        private string $modificationType,
+        public string $description,
+        private bool $isBcBreak,
+        public ?string $file = null,
+        public ?int $line = null,
+        public ?int $column = null
+    ) {
     }
 
     /** @psalm-pure */
@@ -73,6 +69,33 @@ final class Change
     public function isSkipped(): bool
     {
         return $this->modificationType === self::SKIPPED;
+    }
+
+    public function onFile(?string $file): self
+    {
+        $instance = clone $this;
+
+        $instance->file = $file;
+
+        return $instance;
+    }
+
+    public function onLine(int $line): self
+    {
+        $instance = clone $this;
+
+        $instance->line = $line;
+
+        return $instance;
+    }
+
+    public function onColumn(?int $column): self
+    {
+        $instance = clone $this;
+
+        $instance->column = $column;
+
+        return $instance;
     }
 
     public function __toString(): string

--- a/src/Change.php
+++ b/src/Change.php
@@ -71,6 +71,21 @@ final class Change
         return $this->modificationType === self::SKIPPED;
     }
 
+    /** @internal */
+    public function withFilePositionsIfNotAlreadySet(
+        ?string $file,
+        int $line,
+        ?int $column
+    ): self {
+        $instance = clone $this;
+
+        $instance->file   ??= $file;
+        $instance->line   ??= $line;
+        $instance->column ??= $column;
+
+        return $instance;
+    }
+
     public function onFile(?string $file): self
     {
         $instance = clone $this;

--- a/src/DetectChanges/BCBreak/ClassBased/MultipleChecksOnAClass.php
+++ b/src/DetectChanges/BCBreak/ClassBased/MultipleChecksOnAClass.php
@@ -6,6 +6,7 @@ namespace Roave\BackwardCompatibility\DetectChanges\BCBreak\ClassBased;
 
 use Roave\BackwardCompatibility\Change;
 use Roave\BackwardCompatibility\Changes;
+use Roave\BackwardCompatibility\Formatter\SymbolStartColumn;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 
 final class MultipleChecksOnAClass implements ClassBased
@@ -26,8 +27,19 @@ final class MultipleChecksOnAClass implements ClassBased
     /** @return iterable<int, Change> */
     private function multipleChecks(ReflectionClass $fromClass, ReflectionClass $toClass): iterable
     {
+        $toFile   = $toClass->getFileName();
+        $toLine   = $toClass->getStartLine();
+        $toColumn = SymbolStartColumn::get($toClass);
+
         foreach ($this->checks as $check) {
-            yield from $check($fromClass, $toClass);
+            foreach ($check($fromClass, $toClass) as $change) {
+                // Note: this approach allows us to quickly add file/line/column to each change, but in future,
+                //       we will need to push this concern into each checker instead.
+                yield $change
+                    ->onFile($toFile)
+                    ->onLine($toLine)
+                    ->onColumn($toColumn);
+            }
         }
     }
 }

--- a/src/DetectChanges/BCBreak/ClassBased/MultipleChecksOnAClass.php
+++ b/src/DetectChanges/BCBreak/ClassBased/MultipleChecksOnAClass.php
@@ -35,10 +35,7 @@ final class MultipleChecksOnAClass implements ClassBased
             foreach ($check($fromClass, $toClass) as $change) {
                 // Note: this approach allows us to quickly add file/line/column to each change, but in future,
                 //       we will need to push this concern into each checker instead.
-                yield $change
-                    ->onFile($toFile)
-                    ->onLine($toLine)
-                    ->onColumn($toColumn);
+                yield $change->withFilePositionsIfNotAlreadySet($toFile, $toLine, $toColumn);
             }
         }
     }

--- a/src/DetectChanges/BCBreak/ClassConstantBased/MultipleChecksOnAClassConstant.php
+++ b/src/DetectChanges/BCBreak/ClassConstantBased/MultipleChecksOnAClassConstant.php
@@ -36,10 +36,7 @@ final class MultipleChecksOnAClassConstant implements ClassConstantBased
             foreach ($check($fromConstant, $toConstant) as $change) {
                 // Note: this approach allows us to quickly add file/line/column to each change, but in future,
                 //       we will need to push this concern into each checker instead.
-                yield $change
-                    ->onFile($toFile)
-                    ->onLine($toLine)
-                    ->onColumn($toColumn);
+                yield $change->withFilePositionsIfNotAlreadySet($toFile, $toLine, $toColumn);
             }
         }
     }

--- a/src/DetectChanges/BCBreak/FunctionBased/MultipleChecksOnAFunction.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/MultipleChecksOnAFunction.php
@@ -47,10 +47,7 @@ final class MultipleChecksOnAFunction implements FunctionBased
             foreach ($check($fromFunction, $toFunction) as $change) {
                 // Note: this approach allows us to quickly add file/line/column to each change, but in future,
                 //       we will need to push this concern into each checker instead.
-                yield $change
-                    ->onFile($toFile)
-                    ->onLine($toLine)
-                    ->onColumn($toColumn);
+                yield $change->withFilePositionsIfNotAlreadySet($toFile, $toLine, $toColumn);
             }
         }
     }

--- a/src/DetectChanges/BCBreak/InterfaceBased/MultipleChecksOnAnInterface.php
+++ b/src/DetectChanges/BCBreak/InterfaceBased/MultipleChecksOnAnInterface.php
@@ -35,10 +35,7 @@ final class MultipleChecksOnAnInterface implements InterfaceBased
             foreach ($check($fromInterface, $toInterface) as $change) {
                 // Note: this approach allows us to quickly add file/line/column to each change, but in future,
                 //       we will need to push this concern into each checker instead.
-                yield $change
-                    ->onFile($toFile)
-                    ->onLine($toLine)
-                    ->onColumn($toColumn);
+                yield $change->withFilePositionsIfNotAlreadySet($toFile, $toLine, $toColumn);
             }
         }
     }

--- a/src/DetectChanges/BCBreak/InterfaceBased/MultipleChecksOnAnInterface.php
+++ b/src/DetectChanges/BCBreak/InterfaceBased/MultipleChecksOnAnInterface.php
@@ -6,6 +6,7 @@ namespace Roave\BackwardCompatibility\DetectChanges\BCBreak\InterfaceBased;
 
 use Roave\BackwardCompatibility\Change;
 use Roave\BackwardCompatibility\Changes;
+use Roave\BackwardCompatibility\Formatter\SymbolStartColumn;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 
 final class MultipleChecksOnAnInterface implements InterfaceBased
@@ -26,8 +27,19 @@ final class MultipleChecksOnAnInterface implements InterfaceBased
     /** @return iterable<int, Change> */
     private function multipleChecks(ReflectionClass $fromInterface, ReflectionClass $toInterface): iterable
     {
+        $toFile   = $toInterface->getFileName();
+        $toLine   = $toInterface->getStartLine();
+        $toColumn = SymbolStartColumn::get($toInterface);
+
         foreach ($this->checks as $check) {
-            yield from $check($fromInterface, $toInterface);
+            foreach ($check($fromInterface, $toInterface) as $change) {
+                // Note: this approach allows us to quickly add file/line/column to each change, but in future,
+                //       we will need to push this concern into each checker instead.
+                yield $change
+                    ->onFile($toFile)
+                    ->onLine($toLine)
+                    ->onColumn($toColumn);
+            }
         }
     }
 }

--- a/src/DetectChanges/BCBreak/MethodBased/MultipleChecksOnAMethod.php
+++ b/src/DetectChanges/BCBreak/MethodBased/MultipleChecksOnAMethod.php
@@ -6,6 +6,7 @@ namespace Roave\BackwardCompatibility\DetectChanges\BCBreak\MethodBased;
 
 use Roave\BackwardCompatibility\Change;
 use Roave\BackwardCompatibility\Changes;
+use Roave\BackwardCompatibility\Formatter\SymbolStartColumn;
 use Roave\BetterReflection\Reflection\ReflectionMethod;
 
 final class MultipleChecksOnAMethod implements MethodBased
@@ -26,8 +27,19 @@ final class MultipleChecksOnAMethod implements MethodBased
     /** @return iterable<int, Change> */
     private function multipleChecks(ReflectionMethod $fromMethod, ReflectionMethod $toMethod): iterable
     {
+        $toFile   = $toMethod->getFileName();
+        $toLine   = $toMethod->getStartLine();
+        $toColumn = SymbolStartColumn::get($toMethod);
+
         foreach ($this->checks as $check) {
-            yield from $check($fromMethod, $toMethod);
+            foreach ($check($fromMethod, $toMethod) as $change) {
+                // Note: this approach allows us to quickly add file/line/column to each change, but in future,
+                //       we will need to push this concern into each checker instead.
+                yield $change
+                    ->onFile($toFile)
+                    ->onLine($toLine)
+                    ->onColumn($toColumn);
+            }
         }
     }
 }

--- a/src/DetectChanges/BCBreak/MethodBased/MultipleChecksOnAMethod.php
+++ b/src/DetectChanges/BCBreak/MethodBased/MultipleChecksOnAMethod.php
@@ -35,10 +35,7 @@ final class MultipleChecksOnAMethod implements MethodBased
             foreach ($check($fromMethod, $toMethod) as $change) {
                 // Note: this approach allows us to quickly add file/line/column to each change, but in future,
                 //       we will need to push this concern into each checker instead.
-                yield $change
-                    ->onFile($toFile)
-                    ->onLine($toLine)
-                    ->onColumn($toColumn);
+                yield $change->withFilePositionsIfNotAlreadySet($toFile, $toLine, $toColumn);
             }
         }
     }

--- a/src/DetectChanges/BCBreak/PropertyBased/MultipleChecksOnAProperty.php
+++ b/src/DetectChanges/BCBreak/PropertyBased/MultipleChecksOnAProperty.php
@@ -36,10 +36,7 @@ final class MultipleChecksOnAProperty implements PropertyBased
             foreach ($check($fromProperty, $toProperty) as $change) {
                 // Note: this approach allows us to quickly add file/line/column to each change, but in future,
                 //       we will need to push this concern into each checker instead.
-                yield $change
-                    ->onFile($toFile)
-                    ->onLine($toLine)
-                    ->onColumn($toColumn);
+                yield $change->withFilePositionsIfNotAlreadySet($toFile, $toLine, $toColumn);
             }
         }
     }

--- a/src/DetectChanges/BCBreak/PropertyBased/MultipleChecksOnAProperty.php
+++ b/src/DetectChanges/BCBreak/PropertyBased/MultipleChecksOnAProperty.php
@@ -6,6 +6,7 @@ namespace Roave\BackwardCompatibility\DetectChanges\BCBreak\PropertyBased;
 
 use Roave\BackwardCompatibility\Change;
 use Roave\BackwardCompatibility\Changes;
+use Roave\BackwardCompatibility\Formatter\SymbolStartColumn;
 use Roave\BetterReflection\Reflection\ReflectionProperty;
 
 final class MultipleChecksOnAProperty implements PropertyBased
@@ -26,8 +27,20 @@ final class MultipleChecksOnAProperty implements PropertyBased
     /** @return iterable<int, Change> */
     private function multipleChecks(ReflectionProperty $fromProperty, ReflectionProperty $toProperty): iterable
     {
+        $toLine   = $toProperty->getStartLine();
+        $toColumn = SymbolStartColumn::get($toProperty);
+        $toFile   = $toProperty->getImplementingClass()
+            ->getFileName();
+
         foreach ($this->checks as $check) {
-            yield from $check($fromProperty, $toProperty);
+            foreach ($check($fromProperty, $toProperty) as $change) {
+                // Note: this approach allows us to quickly add file/line/column to each change, but in future,
+                //       we will need to push this concern into each checker instead.
+                yield $change
+                    ->onFile($toFile)
+                    ->onLine($toLine)
+                    ->onColumn($toColumn);
+            }
         }
     }
 }

--- a/src/DetectChanges/BCBreak/TraitBased/MultipleChecksOnATrait.php
+++ b/src/DetectChanges/BCBreak/TraitBased/MultipleChecksOnATrait.php
@@ -35,10 +35,7 @@ final class MultipleChecksOnATrait implements TraitBased
             foreach ($check($fromTrait, $toTrait) as $change) {
                 // Note: this approach allows us to quickly add file/line/column to each change, but in future,
                 //       we will need to push this concern into each checker instead.
-                yield $change
-                    ->onFile($toFile)
-                    ->onLine($toLine)
-                    ->onColumn($toColumn);
+                yield $change->withFilePositionsIfNotAlreadySet($toFile, $toLine, $toColumn);
             }
         }
     }

--- a/src/Formatter/GithubActionsFormatter.php
+++ b/src/Formatter/GithubActionsFormatter.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BackwardCompatibility\Formatter;
+
+use Psl\Str;
+use Roave\BackwardCompatibility\Changes;
+use Roave\BackwardCompatibility\Git\CheckedOutRepository;
+use Symfony\Component\Console\CI\GithubActionReporter;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/** @internal */
+final class GithubActionsFormatter implements OutputFormatter
+{
+    public function __construct(
+        private OutputInterface $output,
+        private CheckedOutRepository $basePath
+    ) {
+    }
+
+    public function write(Changes $changes): void
+    {
+        $reporter = new GithubActionReporter($this->output);
+        $basePath = $this->basePath->__toString() . '/';
+
+        foreach ($changes as $change) {
+            $reporter->error(
+                $change->description,
+                $change->file === null
+                    ? null
+                    : Str\replace($change->file, $basePath, ''),
+                $change->line,
+                $change->column
+            );
+        }
+    }
+}

--- a/src/Formatter/SymbolStartColumn.php
+++ b/src/Formatter/SymbolStartColumn.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BackwardCompatibility\Formatter;
+
+use Roave\BetterReflection\Reflection\ReflectionClass;
+use Roave\BetterReflection\Reflection\ReflectionClassConstant;
+use Roave\BetterReflection\Reflection\ReflectionConstant;
+use Roave\BetterReflection\Reflection\ReflectionFunction;
+use Roave\BetterReflection\Reflection\ReflectionMethod;
+use Roave\BetterReflection\Reflection\ReflectionProperty;
+use Roave\BetterReflection\Util\Exception\InvalidNodePosition;
+use Roave\BetterReflection\Util\Exception\NoNodePosition;
+
+/** @internal */
+final class SymbolStartColumn
+{
+    /**
+     * Determines the column at which a given symbol starts, if able to do so.
+     *
+     * Mostly exists because the reflection logic may be configured to skip parsing/collecting
+     * AST node exact positions, and because some sources (especially if stubbed from PHP core)
+     * could have trouble identifying the position of a symbol, given that some of them are
+     * declared via custom AST added by `roave/better-reflection` post-parsing (such as `__toString()`
+     * in {@see \Stringable::__toString()}).
+     */
+    public static function get(
+        ReflectionFunction|ReflectionMethod|ReflectionProperty|ReflectionClass|ReflectionClassConstant|ReflectionConstant $symbol
+    ): int|null {
+        try {
+            return $symbol->getStartColumn();
+        } catch (NoNodePosition | InvalidNodePosition) {
+            return null;
+        }
+    }
+}

--- a/test/unit/ChangeTest.php
+++ b/test/unit/ChangeTest.php
@@ -47,6 +47,18 @@ final class ChangeTest extends TestCase
         self::assertFalse($change->isRemoved());
     }
 
+    public function testCanRecordFileLineAndColumnPosition(): void
+    {
+        $change = Change::changed('foo', false)
+            ->onFile('a-file')
+            ->onLine(123)
+            ->onColumn(456);
+
+        self::assertSame('a-file', $change->file);
+        self::assertSame(123, $change->line);
+        self::assertSame(456, $change->column);
+    }
+
     public function testBcChanged(): void
     {
         $changeText = uniqid('changeText', true);

--- a/test/unit/ChangeTest.php
+++ b/test/unit/ChangeTest.php
@@ -59,6 +59,18 @@ final class ChangeTest extends TestCase
         self::assertSame(456, $change->column);
     }
 
+    public function testWillNotOverrideFilePositionsIfAlreadySet(): void
+    {
+        $change = Change::changed('foo', false)
+            ->withFilePositionsIfNotAlreadySet('foo.php', 10, 20)
+            ->withFilePositionsIfNotAlreadySet('bar.php', 30, 40)
+            ->withFilePositionsIfNotAlreadySet('baz.php', 50, 60);
+
+        self::assertSame('foo.php', $change->file);
+        self::assertSame(10, $change->line);
+        self::assertSame(20, $change->column);
+    }
+
     public function testBcChanged(): void
     {
         $changeText = uniqid('changeText', true);

--- a/test/unit/Command/AssertBackwardsCompatibleTest.php
+++ b/test/unit/Command/AssertBackwardsCompatibleTest.php
@@ -238,6 +238,7 @@ final class AssertBackwardsCompatibleTest extends TestCase
             ['from', $fromSha],
             ['to', $toSha],
             ['install-development-dependencies', false],
+            ['format', ['console']],
         ]);
         $this->input->method('getArgument')->willReturnMap([
             ['sources-path', 'src'],

--- a/test/unit/DetectChanges/BCBreak/ClassBased/MultipleChecksOnAClassTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/MultipleChecksOnAClassTest.php
@@ -28,6 +28,13 @@ final class MultipleChecksOnAClassTest extends TestCase
         $from = $this->createMock(ReflectionClass::class);
         $to   = $this->createMock(ReflectionClass::class);
 
+        $to->method('getFileName')
+            ->willReturn('foo.php');
+        $to->method('getStartLine')
+            ->willReturn(10);
+        $to->method('getStartColumn')
+            ->willReturn(5);
+
         $checker1
             ->expects(self::once())
             ->method('__invoke')
@@ -48,9 +55,18 @@ final class MultipleChecksOnAClassTest extends TestCase
 
         Assertion::assertChangesEqual(
             Changes::fromList(
-                Change::added('1', true),
-                Change::added('2', true),
+                Change::added('1', true)
+                    ->onFile('foo.php')
+                    ->onLine(10)
+                    ->onColumn(5),
+                Change::added('2', true)
+                    ->onFile('foo.php')
+                    ->onLine(10)
+                    ->onColumn(5),
                 Change::added('3', true)
+                    ->onFile('foo.php')
+                    ->onLine(10)
+                    ->onColumn(5),
             ),
             $multiCheck($from, $to)
         );

--- a/test/unit/DetectChanges/BCBreak/ClassConstantBased/MultipleChecksOnAClassConstantTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassConstantBased/MultipleChecksOnAClassConstantTest.php
@@ -9,6 +9,7 @@ use Roave\BackwardCompatibility\Change;
 use Roave\BackwardCompatibility\Changes;
 use Roave\BackwardCompatibility\DetectChanges\BCBreak\ClassConstantBased\ClassConstantBased;
 use Roave\BackwardCompatibility\DetectChanges\BCBreak\ClassConstantBased\MultipleChecksOnAClassConstant;
+use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionClassConstant;
 use RoaveTest\BackwardCompatibility\Assertion;
 
@@ -25,8 +26,18 @@ final class MultipleChecksOnAClassConstantTest extends TestCase
 
         $multiCheck = new MultipleChecksOnAClassConstant($checker1, $checker2, $checker3);
 
-        $from = $this->createMock(ReflectionClassConstant::class);
-        $to   = $this->createMock(ReflectionClassConstant::class);
+        $from    = $this->createMock(ReflectionClassConstant::class);
+        $to      = $this->createMock(ReflectionClassConstant::class);
+        $toClass = $this->createMock(ReflectionClass::class);
+
+        $to->method('getStartLine')
+            ->willReturn(10);
+        $to->method('getStartColumn')
+            ->willReturn(5);
+        $toClass->method('getFileName')
+            ->willReturn('foo.php');
+        $to->method('getDeclaringClass')
+            ->willReturn($toClass);
 
         $checker1
             ->expects(self::once())
@@ -48,9 +59,18 @@ final class MultipleChecksOnAClassConstantTest extends TestCase
 
         Assertion::assertChangesEqual(
             Changes::fromList(
-                Change::added('1', true),
-                Change::added('2', true),
+                Change::added('1', true)
+                    ->onFile('foo.php')
+                    ->onLine(10)
+                    ->onColumn(5),
+                Change::added('2', true)
+                    ->onFile('foo.php')
+                    ->onLine(10)
+                    ->onColumn(5),
                 Change::added('3', true)
+                    ->onFile('foo.php')
+                    ->onLine(10)
+                    ->onColumn(5),
             ),
             $multiCheck($from, $to)
         );

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/MultipleChecksOnAFunctionTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/MultipleChecksOnAFunctionTest.php
@@ -28,6 +28,13 @@ final class MultipleChecksOnAFunctionTest extends TestCase
         $from = $this->createMock(ReflectionFunction::class);
         $to   = $this->createMock(ReflectionFunction::class);
 
+        $to->method('getFileName')
+            ->willReturn('foo.php');
+        $to->method('getStartLine')
+            ->willReturn(10);
+        $to->method('getStartColumn')
+            ->willReturn(5);
+
         $checker1
             ->expects(self::once())
             ->method('__invoke')
@@ -48,9 +55,18 @@ final class MultipleChecksOnAFunctionTest extends TestCase
 
         Assertion::assertChangesEqual(
             Changes::fromList(
-                Change::added('1', true),
-                Change::added('2', true),
+                Change::added('1', true)
+                    ->onFile('foo.php')
+                    ->onLine(10)
+                    ->onColumn(5),
+                Change::added('2', true)
+                    ->onFile('foo.php')
+                    ->onLine(10)
+                    ->onColumn(5),
                 Change::added('3', true)
+                    ->onFile('foo.php')
+                    ->onLine(10)
+                    ->onColumn(5),
             ),
             $multiCheck($from, $to)
         );

--- a/test/unit/DetectChanges/BCBreak/InterfaceBased/MultipleChecksOnAnInterfaceTest.php
+++ b/test/unit/DetectChanges/BCBreak/InterfaceBased/MultipleChecksOnAnInterfaceTest.php
@@ -28,6 +28,13 @@ final class MultipleChecksOnAnInterfaceTest extends TestCase
         $from = $this->createMock(ReflectionClass::class);
         $to   = $this->createMock(ReflectionClass::class);
 
+        $to->method('getFileName')
+            ->willReturn('foo.php');
+        $to->method('getStartLine')
+            ->willReturn(10);
+        $to->method('getStartColumn')
+            ->willReturn(5);
+
         $checker1
             ->expects(self::once())
             ->method('__invoke')
@@ -48,9 +55,18 @@ final class MultipleChecksOnAnInterfaceTest extends TestCase
 
         Assertion::assertChangesEqual(
             Changes::fromList(
-                Change::added('1', true),
-                Change::added('2', true),
+                Change::added('1', true)
+                    ->onFile('foo.php')
+                    ->onLine(10)
+                    ->onColumn(5),
+                Change::added('2', true)
+                    ->onFile('foo.php')
+                    ->onLine(10)
+                    ->onColumn(5),
                 Change::added('3', true)
+                    ->onFile('foo.php')
+                    ->onLine(10)
+                    ->onColumn(5),
             ),
             $multiCheck($from, $to)
         );

--- a/test/unit/DetectChanges/BCBreak/MethodBased/MultipleChecksOnAMethodTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/MultipleChecksOnAMethodTest.php
@@ -28,6 +28,13 @@ final class MultipleChecksOnAMethodTest extends TestCase
         $from = $this->createMock(ReflectionMethod::class);
         $to   = $this->createMock(ReflectionMethod::class);
 
+        $to->method('getFileName')
+            ->willReturn('foo.php');
+        $to->method('getStartLine')
+            ->willReturn(10);
+        $to->method('getStartColumn')
+            ->willReturn(5);
+
         $checker1
             ->expects(self::once())
             ->method('__invoke')
@@ -48,9 +55,18 @@ final class MultipleChecksOnAMethodTest extends TestCase
 
         Assertion::assertChangesEqual(
             Changes::fromList(
-                Change::added('1', true),
-                Change::added('2', true),
+                Change::added('1', true)
+                    ->onFile('foo.php')
+                    ->onLine(10)
+                    ->onColumn(5),
+                Change::added('2', true)
+                    ->onFile('foo.php')
+                    ->onLine(10)
+                    ->onColumn(5),
                 Change::added('3', true)
+                    ->onFile('foo.php')
+                    ->onLine(10)
+                    ->onColumn(5),
             ),
             $multiCheck($from, $to)
         );

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/MultipleChecksOnAPropertyTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/MultipleChecksOnAPropertyTest.php
@@ -9,6 +9,7 @@ use Roave\BackwardCompatibility\Change;
 use Roave\BackwardCompatibility\Changes;
 use Roave\BackwardCompatibility\DetectChanges\BCBreak\PropertyBased\MultipleChecksOnAProperty;
 use Roave\BackwardCompatibility\DetectChanges\BCBreak\PropertyBased\PropertyBased;
+use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionProperty;
 use RoaveTest\BackwardCompatibility\Assertion;
 
@@ -25,8 +26,18 @@ final class MultipleChecksOnAPropertyTest extends TestCase
 
         $multiCheck = new MultipleChecksOnAProperty($checker1, $checker2, $checker3);
 
-        $from = $this->createMock(ReflectionProperty::class);
-        $to   = $this->createMock(ReflectionProperty::class);
+        $from    = $this->createMock(ReflectionProperty::class);
+        $to      = $this->createMock(ReflectionProperty::class);
+        $toClass = $this->createMock(ReflectionClass::class);
+
+        $to->method('getStartLine')
+            ->willReturn(10);
+        $to->method('getStartColumn')
+            ->willReturn(5);
+        $toClass->method('getFileName')
+            ->willReturn('foo.php');
+        $to->method('getImplementingClass')
+            ->willReturn($toClass);
 
         $checker1
             ->expects(self::once())
@@ -48,9 +59,18 @@ final class MultipleChecksOnAPropertyTest extends TestCase
 
         Assertion::assertChangesEqual(
             Changes::fromList(
-                Change::added('1', true),
-                Change::added('2', true),
+                Change::added('1', true)
+                    ->onFile('foo.php')
+                    ->onLine(10)
+                    ->onColumn(5),
+                Change::added('2', true)
+                    ->onFile('foo.php')
+                    ->onLine(10)
+                    ->onColumn(5),
                 Change::added('3', true)
+                    ->onFile('foo.php')
+                    ->onLine(10)
+                    ->onColumn(5),
             ),
             $multiCheck($from, $to)
         );

--- a/test/unit/DetectChanges/BCBreak/TraitBased/MultipleChecksOnATraitTest.php
+++ b/test/unit/DetectChanges/BCBreak/TraitBased/MultipleChecksOnATraitTest.php
@@ -28,6 +28,13 @@ final class MultipleChecksOnATraitTest extends TestCase
         $from = $this->createMock(ReflectionClass::class);
         $to   = $this->createMock(ReflectionClass::class);
 
+        $to->method('getFileName')
+            ->willReturn('foo.php');
+        $to->method('getStartLine')
+            ->willReturn(10);
+        $to->method('getStartColumn')
+            ->willReturn(5);
+
         $checker1
             ->expects(self::once())
             ->method('__invoke')
@@ -48,9 +55,18 @@ final class MultipleChecksOnATraitTest extends TestCase
 
         Assertion::assertChangesEqual(
             Changes::fromList(
-                Change::added('1', true),
-                Change::added('2', true),
+                Change::added('1', true)
+                    ->onFile('foo.php')
+                    ->onLine(10)
+                    ->onColumn(5),
+                Change::added('2', true)
+                    ->onFile('foo.php')
+                    ->onLine(10)
+                    ->onColumn(5),
                 Change::added('3', true)
+                    ->onFile('foo.php')
+                    ->onLine(10)
+                    ->onColumn(5),
             ),
             $multiCheck($from, $to)
         );

--- a/test/unit/Formatter/FunctionNameTest.php
+++ b/test/unit/Formatter/FunctionNameTest.php
@@ -15,12 +15,12 @@ use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
 /**
  * @covers \Roave\BackwardCompatibility\Formatter\FunctionName
  */
-final class ReflectionFunctionAbstractNameTest extends TestCase
+final class FunctionNameTest extends TestCase
 {
     /**
      * @dataProvider functionsToBeTested
      */
-    public function testName(ReflectionFunction|ReflectionMethod $function, string $expectedName) : void
+    public function testName(ReflectionFunction|ReflectionMethod $function, string $expectedName): void
     {
         self::assertSame($expectedName, (new FunctionName())($function));
     }
@@ -31,7 +31,7 @@ final class ReflectionFunctionAbstractNameTest extends TestCase
      *     1: string
      * }>
      */
-    public function functionsToBeTested() : array
+    public function functionsToBeTested(): array
     {
         $locator = new StringSourceLocator(
             <<<'PHP'
@@ -56,7 +56,7 @@ PHP
             (new BetterReflection())->astLocator()
         );
 
-        $reflector    = new DefaultReflector($locator);
+        $reflector = new DefaultReflector($locator);
 
         return [
             'a'       => [

--- a/test/unit/Formatter/GithubActionsFormatterTest.php
+++ b/test/unit/Formatter/GithubActionsFormatterTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoaveTest\BackwardCompatibility\Formatter;
+
+use PHPUnit\Framework\TestCase;
+use Psl\Filesystem;
+use ReflectionException;
+use Roave\BackwardCompatibility\Change;
+use Roave\BackwardCompatibility\Changes;
+use Roave\BackwardCompatibility\Formatter\GithubActionsFormatter;
+use Roave\BackwardCompatibility\Git\CheckedOutRepository;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+use function sys_get_temp_dir;
+use function tempnam;
+
+/** @covers \Roave\BackwardCompatibility\Formatter\GithubActionsFormatter */
+final class GithubActionsFormatterTest extends TestCase
+{
+    /**
+     * @throws ReflectionException
+     */
+    public function testWrite(): void
+    {
+        $output            = new BufferedOutput();
+        $temporaryLocation = tempnam(sys_get_temp_dir(), 'githubActionsFormatter');
+
+        Filesystem\delete_file($temporaryLocation);
+        Filesystem\create_directory($temporaryLocation . '/foo/bar/.git');
+
+        (new GithubActionsFormatter(
+            $output,
+            CheckedOutRepository::fromPath($temporaryLocation . '/foo/bar')
+        ))->write(Changes::fromList(
+            Change::removed('foo', true),
+            Change::added('bar', false),
+            Change::changed('baz', false)
+                ->onFile('baz-file.php'),
+            Change::changed('tab', false)
+                ->onFile('tab-file.php')
+                ->onLine(5),
+            Change::changed('taz', false)
+                ->onFile('taz-file.php')
+                ->onLine(6)
+                ->onColumn(15),
+            Change::changed('tar', false)
+                ->onFile('tar-file.php')
+                ->onLine(-1)
+                ->onColumn(-1),
+            Change::changed('file-in-checked-out-dir', false)
+                ->onFile($temporaryLocation . '/foo/bar/subpath/file-in-checked-out-dir.php')
+                ->onLine(10)
+                ->onColumn(20),
+        ));
+
+        self::assertEquals(
+            <<<'OUTPUT'
+::error::foo
+::error::bar
+::error file=baz-file.php,line=1,col=0::baz
+::error file=tab-file.php,line=5,col=0::tab
+::error file=taz-file.php,line=6,col=15::taz
+::error file=tar-file.php,line=-1,col=-1::tar
+::error file=subpath/file-in-checked-out-dir.php,line=10,col=20::file-in-checked-out-dir
+
+OUTPUT
+            ,
+            $output->fetch()
+        );
+
+        Filesystem\delete_directory($temporaryLocation, true);
+    }
+}

--- a/test/unit/Formatter/SymbolStartColumnTest.php
+++ b/test/unit/Formatter/SymbolStartColumnTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoaveTest\BackwardCompatibility\Formatter;
+
+use BadMethodCallException;
+use PhpParser\Node\Stmt\Function_;
+use PHPUnit\Framework\TestCase;
+use Psl\Type;
+use Roave\BackwardCompatibility\Formatter\SymbolStartColumn;
+use Roave\BetterReflection\BetterReflection;
+use Roave\BetterReflection\Identifier\Identifier;
+use Roave\BetterReflection\Identifier\IdentifierType;
+use Roave\BetterReflection\Reflection\Reflection;
+use Roave\BetterReflection\Reflection\ReflectionFunction;
+use Roave\BetterReflection\Reflector\DefaultReflector;
+use Roave\BetterReflection\Reflector\Reflector;
+use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
+use Roave\BetterReflection\SourceLocator\Type\SourceLocator;
+use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
+
+/**
+ * @covers \Roave\BackwardCompatibility\Formatter\SymbolStartColumn
+ */
+final class SymbolStartColumnTest extends TestCase
+{
+    public function testCanGetStartColumnForSimpleSymbol(): void
+    {
+        $reflector = new DefaultReflector(new StringSourceLocator(
+            '<?php /* spacing on purpose */ class A {}',
+            (new BetterReflection())->astLocator()
+        ));
+
+        self::assertSame(32, SymbolStartColumn::get($reflector->reflectClass('A')));
+    }
+
+    public function testCannotGetStartColumnWhenAstHasBeenParsedWithoutColumnLocations(): void
+    {
+        $reflector = new DefaultReflector(new class implements SourceLocator {
+            /** Retrieves function `foo`, but without sources (invalid position) */
+            public function locateIdentifier(Reflector $reflector, Identifier $identifier): ?Reflection
+            {
+                $locatedSource    = new LocatedSource('', null);
+                $betterReflection = new BetterReflection();
+
+                $function = Type\shape([
+                    0 => Type\object(Function_::class),
+                ])->coerce(
+                    $betterReflection->phpParser()
+                        ->parse('<?php function foo() {}')
+                )[0];
+
+                return ReflectionFunction::createFromNode(
+                    $betterReflection->reflector(),
+                    $function,
+                    $locatedSource
+                );
+            }
+
+            /** {@inheritDoc} */
+            public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType): array
+            {
+                throw new BadMethodCallException('Unused');
+            }
+        });
+
+        self::assertNull(SymbolStartColumn::get($reflector->reflectFunction('foo')));
+    }
+}


### PR DESCRIPTION
This change adds a `--format=github-actions` option, allowing for friendlier output
for GitHub actions.

Note that this addition, while functionally working, is implemented by hacking through
the `MultipleChecksOn*` implementations, which decorate the various `Change` instances
produced by individual checkers. In future, we will need to clean this up, so that there
is a simpler API for creating `Change` instances from a reflected symbol.

Fixes #342