### PR TITLE
Fixed Markdown output not returning skipped items

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,10 @@
         "sort-packages": true,
         "platform": {
             "php": "8.0.99"
+        },
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "infection/extension-installer": true
         }
     }
 }

--- a/src/Formatter/MarkdownPipedToSymfonyConsoleFormatter.php
+++ b/src/Formatter/MarkdownPipedToSymfonyConsoleFormatter.php
@@ -45,6 +45,13 @@ final class MarkdownPipedToSymfonyConsoleFormatter implements OutputFormatter
                 },
                 ...$arrayOfChanges
             ), '')
+            . "\n# Skipped\n"
+            . Str\join($this->convertFilteredChangesToMarkdownBulletList(
+                static function (Change $change): bool {
+                    return $change->isSkipped();
+                },
+                ...$arrayOfChanges
+            ), '')
         );
     }
 
@@ -58,7 +65,7 @@ final class MarkdownPipedToSymfonyConsoleFormatter implements OutputFormatter
         return Vec\map(
             Vec\filter($changes, $filterFunction),
             static function (Change $change): string {
-                return ' - ' . Str\replace_every(Str\trim($change->__toString()), ['ADDED: ' => '', 'CHANGED: ' => '', 'REMOVED: ' => '']) . "\n";
+                return ' - ' . Str\replace_every(Str\trim($change->__toString()), ['ADDED: ' => '', 'CHANGED: ' => '', 'REMOVED: ' => '', 'SKIPPED: ' => '']) . "\n";
             }
         );
     }

--- a/test/unit/Formatter/MarkdownPipedToSymfonyConsoleFormatterTest.php
+++ b/test/unit/Formatter/MarkdownPipedToSymfonyConsoleFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace RoaveTest\BackwardCompatibility\Formatter;
 
+use Exception;
 use PHPUnit\Framework\TestCase;
 use Roave\BackwardCompatibility\Change;
 use Roave\BackwardCompatibility\Changes;
@@ -32,6 +33,9 @@ final class MarkdownPipedToSymfonyConsoleFormatterTest extends TestCase
  - [BC] Something removed
  - Something removed
 
+# Skipped
+ - [BC] A failure happened
+
 EOF;
 
         $output->expects(self::once())
@@ -46,7 +50,8 @@ EOF;
             Change::changed('Something changed', true),
             Change::changed('Something changed', false),
             Change::removed('Something removed', true),
-            Change::removed('Something removed', false)
+            Change::removed('Something removed', false),
+            Change::skippedDueToFailure(new Exception('A failure happened')),
         ));
     }
 }


### PR DESCRIPTION
I noticed a discrepancy between the number of BC changes detected, and the number written in the `markdown` output formatter on a project:

```
# Added

# Changed
 - [BC] Value of constant Twig\Environment::VERSION changed from '3.3.0' to '3.3.4'
 - [BC] Value of constant Twig\Environment::VERSION_ID changed from 30300 to 30304
 - [BC] Value of constant Twig\Environment::RELEASE_VERSION changed from 0 to 4

# Removed

21 backwards-incompatible changes detected
```

This does NOT happen when using the `console` formatter:

```
[BC] SKIPPED: Roave\BetterReflection\Reflection\ReflectionClass "Symfony\Component\HttpKernel\Event\FilterControllerEvent" could not be found in the located source
[BC] SKIPPED: Roave\BetterReflection\Reflection\ReflectionClass "Symfony\Component\HttpKernel\Event\FilterControllerEvent" could not be found in the located source
[BC] SKIPPED: Roave\BetterReflection\Reflection\ReflectionClass "Symfony\Component\HttpKernel\Event\FilterControllerEvent" could not be found in the located source
[BC] SKIPPED: Roave\BetterReflection\Reflection\ReflectionClass "Symfony\Component\HttpKernel\Event\FilterControllerEvent" could not be found in the located source
[BC] SKIPPED: Roave\BetterReflection\Reflection\ReflectionClass "Symfony\Component\HttpKernel\Event\FilterControllerEvent" could not be found in the located source
[BC] SKIPPED: Roave\BetterReflection\Reflection\ReflectionClass "Symfony\Component\HttpKernel\Event\FilterControllerEvent" could not be found in the located source
[BC] SKIPPED: Roave\BetterReflection\Reflection\ReflectionClass "Symfony\Component\HttpKernel\Event\FilterControllerEvent" could not be found in the located source
[BC] SKIPPED: Roave\BetterReflection\Reflection\ReflectionClass "Scoutapm\ScoutApmBundle\Twig\TwigMethods" could not be found in the located source
[BC] SKIPPED: Roave\BetterReflection\Reflection\ReflectionClass "Scoutapm\ScoutApmBundle\Twig\TwigMethods" could not be found in the located source
[BC] CHANGED: Value of constant Twig\Environment::VERSION changed from '3.3.0' to '3.3.4'
[BC] CHANGED: Value of constant Twig\Environment::VERSION_ID changed from 30300 to 30304
[BC] CHANGED: Value of constant Twig\Environment::RELEASE_VERSION changed from 0 to 4
[BC] SKIPPED: Roave\BetterReflection\Reflection\ReflectionClass "Scoutapm\ScoutApmBundle\Twig\TwigMethods" could not be found in the located source
[BC] SKIPPED: Roave\BetterReflection\Reflection\ReflectionClass "Scoutapm\ScoutApmBundle\Twig\TwigMethods" could not be found in the located source
[BC] SKIPPED: Roave\BetterReflection\Reflection\ReflectionClass "Symfony\Component\HttpKernel\Event\FilterControllerEvent" could not be found in the located source
[BC] SKIPPED: Roave\BetterReflection\Reflection\ReflectionClass "Symfony\Component\HttpKernel\Event\FilterControllerEvent" could not be found in the located source
[BC] SKIPPED: Roave\BetterReflection\Reflection\ReflectionClass "Symfony\Component\HttpKernel\Event\FilterControllerEvent" could not be found in the located source
[BC] SKIPPED: Roave\BetterReflection\Reflection\ReflectionClass "Symfony\Component\HttpKernel\Event\FilterControllerEvent" could not be found in the located source
[BC] SKIPPED: Roave\BetterReflection\Reflection\ReflectionClass "Symfony\Component\HttpKernel\Event\FilterControllerEvent" could not be found in the located source
[BC] SKIPPED: Roave\BetterReflection\Reflection\ReflectionClass "Symfony\Component\HttpKernel\Event\FilterControllerEvent" could not be found in the located source
[BC] SKIPPED: Roave\BetterReflection\Reflection\ReflectionClass "Symfony\Component\HttpKernel\Event\FilterControllerEvent" could not be found in the located source
21 backwards-incompatible changes detected
```
