### PR TITLE
#429 polyfills should not override reflected internal PHP symbols

### DIFF
--- a/src/LocateDependencies/LocateDependenciesViaComposer.php
+++ b/src/LocateDependencies/LocateDependenciesViaComposer.php
@@ -56,8 +56,8 @@ final class LocateDependenciesViaComposer implements LocateDependencies
         }, $installationPath);
 
         return new AggregateSourceLocator([
-            (new MakeLocatorForInstalledJson())($installationPath, $this->astLocator),
             new PhpInternalSourceLocator($this->astLocator, new ReflectionSourceStubber()),
+            (new MakeLocatorForInstalledJson())($installationPath, $this->astLocator),
         ]);
     }
 

--- a/test/asset/composer-installation-with-vendor-overriding-internal-sources/composer.json
+++ b/test/asset/composer-installation-with-vendor-overriding-internal-sources/composer.json
@@ -1,0 +1,3 @@
+{
+    "description": "a package"
+}

--- a/test/asset/composer-installation-with-vendor-overriding-internal-sources/vendor/a/b/stringable-polyfill.php
+++ b/test/asset/composer-installation-with-vendor-overriding-internal-sources/vendor/a/b/stringable-polyfill.php
@@ -1,0 +1,5 @@
+<?php
+
+interface Stringable
+{
+}

--- a/test/asset/composer-installation-with-vendor-overriding-internal-sources/vendor/composer/installed.json
+++ b/test/asset/composer-installation-with-vendor-overriding-internal-sources/vendor/composer/installed.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "a/b",
+    "autoload": {
+      "files": [
+        "stringable-polyfill.php"
+      ]
+    }
+  }
+]

--- a/test/unit/LocateDependencies/LocateDependenciesViaComposerTest.php
+++ b/test/unit/LocateDependencies/LocateDependenciesViaComposerTest.php
@@ -117,7 +117,7 @@ final class LocateDependenciesViaComposerTest extends TestCase
         ])->coerce($reflectionLocators->getValue($locator));
 
         self::assertCount(2, $locators);
-        self::assertInstanceOf(PhpInternalSourceLocator::class, $locators[1]);
+        self::assertInstanceOf(PhpInternalSourceLocator::class, $locators[0]);
     }
 
     public function testInternalReflectionStubsTakePriorityOverInstalledPolyfills(): void
@@ -180,6 +180,6 @@ final class LocateDependenciesViaComposerTest extends TestCase
         ])->coerce($reflectionLocators->getValue($locator));
 
         self::assertCount(2, $locators);
-        self::assertInstanceOf(PhpInternalSourceLocator::class, $locators[1]);
+        self::assertInstanceOf(PhpInternalSourceLocator::class, $locators[0]);
     }
 }

--- a/test/unit/LocateDependencies/LocateDependenciesViaComposerTest.php
+++ b/test/unit/LocateDependencies/LocateDependenciesViaComposerTest.php
@@ -14,6 +14,7 @@ use Psl\Type;
 use ReflectionProperty;
 use Roave\BackwardCompatibility\LocateDependencies\LocateDependenciesViaComposer;
 use Roave\BetterReflection\BetterReflection;
+use Roave\BetterReflection\Reflector\DefaultReflector;
 use Roave\BetterReflection\SourceLocator\Type\AggregateSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\PhpInternalSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\SourceLocator;
@@ -117,6 +118,19 @@ final class LocateDependenciesViaComposerTest extends TestCase
 
         self::assertCount(2, $locators);
         self::assertInstanceOf(PhpInternalSourceLocator::class, $locators[1]);
+    }
+
+    public function testInternalReflectionStubsTakePriorityOverInstalledPolyfills(): void
+    {
+        $this->expectedInstallationPath = Type\string()
+            ->assert(Filesystem\canonicalize(__DIR__ . '/../../asset/composer-installation-with-vendor-overriding-internal-sources'));
+
+        $reflector = new DefaultReflector(($this->locateDependencies)($this->expectedInstallationPath, false));
+
+        self::assertTrue(
+            $reflector->reflectClass('Stringable')
+                ->isInternal()
+        );
     }
 
     public function testDevelopmentDependenciesCanBeOptionallyInstalled(): void


### PR DESCRIPTION
Fixes #429

As discovered in #429 by @weirdan, the `Stringable` interface is not added to symbols, when
the interface is declared by a `vendor/` package.

This leads to the `AncestorRemoved` BC checker (correctly) kicking in, and reporting BC breaks:

> Live example: https://github.com/vimeo/psalm/runs/5059860222?check_suite_focus=true
> ### Steps to reproduce:
>
>     1. Add `roave/backward-compatibility-check:6.1` to a project that didn't use `symfony/polyfill-php80` and that also has some classes with `__toString()` method.
>
>     2. Commit `composer.json` (and `composer.lock` if it's versioned),
>
>     3. Run `vendor/bin/roave-backward-compatibility-check --from="HEAD^"`.
>
>
> ### Expected
>
> No backward compatibility breaks should be reported as no project files have changed.
> ### Actual
>
> ```
> ....
> [BC] REMOVED: These ancestors of Psalm\Storage\Assertion\InArray have been removed: ["Stringable"]
> [BC] REMOVED: These ancestors of Psalm\Storage\FunctionLikeStorage have been removed: ["Stringable"]
> [BC] REMOVED: These ancestors of Psalm\Storage\Assertion have been removed: ["Stringable"]
> [BC] REMOVED: These ancestors of Psalm\Node\VirtualIdentifier have been removed: ["Stringable"]
> [BC] REMOVED: These ancestors of Psalm\Node\VirtualName have been removed: ["Stringable"]
> [BC] REMOVED: These ancestors of Psalm\Node\VirtualVarLikeIdentifier have been removed: ["Stringable"]
> [BC] REMOVED: These ancestors of Psalm\Node\Name\VirtualRelative have been removed: ["Stringable"]
> [BC] REMOVED: These ancestors of Psalm\Node\Name\VirtualFullyQualified have been removed: ["Stringable"]
> 125 backwards-incompatible changes detected
> ```
>
> I also confirmed that it's triggered by `symfony/polyfill-php80` by installing BCC into a separate environment and running `vendor/bin/roave-backward-compatibility-check --from="HEAD^"` with the HEAD commit having just this:
>
> ```diff
> commit 4cc0571866e8405658117613a8106f880116decb (HEAD -> add-bcc-2)
> Author: Bruce Weirdan <weirdan@gmail.com>
> Date:   Fri Feb 4 03:39:44 2022 +0200
>
>     Add polyfill
>
> diff --git a/composer.json b/composer.json
> index f06872480..567e5d275 100644
> --- a/composer.json
> +++ b/composer.json
> @@ -35,7 +35,8 @@
>          "openlss/lib-array2xml": "^1.0",
>          "sebastian/diff": "^4.0",
>          "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0 || ^6.0",
> -        "symfony/filesystem": "^5.4 || ^6.0"
> +        "symfony/filesystem": "^5.4 || ^6.0",
> +        "symfony/polyfill-php80": "^1.24"
>      },
>      "provide": {
>          "psalm/psalm": "self.version"
> ```

As discovered by @ocramius ( https://github.com/Roave/BackwardCompatibilityCheck/issues/429#issuecomment-1030206874 )
the problem is that `symfony/polyfill-php80` declares a non-internal `Stringable` interface, and `BetterReflection`
rightfully does **NOT** use it when deciding whether to add `Stringable` to a class implementing `__toString()`, because
only an internal PHP class would be a valid candidate.

> Aha, found it. In `roave/better-reflection`, we only add the `Stringable` interface to the ancestors in a `ReflectionClass` of our sources if it is an internal class ( https://github.com/Roave/BetterReflection/blob/d5c9a1afe2ed031c1c86aae58d22f70edb586c67/src/Reflection/ReflectionClass.php#L1113-L1144 )
>
> ```
>                     $stringableInterfaceReflection = $this->reflectClassForNamedNode(new Node\Name($stringableClassName));
>
>                     if ($stringableInterfaceReflection->isInternal()) {
>                         $interfaces[$stringableClassName] = $stringableInterfaceReflection;
>                     }
> ```
>
> Obviously, the `symfony/polyfill-php80` is not an internal class, and therefore it is skipped. The trouble is that `Reflector#reflectClass()` finds the one under `symfony/polyfill-php80` before looking at the internal source locators.
>
> This could potentially be fixed by sorting the source locators differently (currently trying that).
>
> NOTE: it is **OK** to ignore `Stringable` if it didn't come from an **internal** source locator - that's because nobody knows what nightmarish contraption people may have invented before PHP 7.x.

With this commit, we put the example in a reproducible test scenario