### PR TITLE
Normalize `__DIR__` and `__FILE__` by changing the base path of `LocatedSource` instances, prevent false-positive BC breaks on those magic constants

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "composer/composer": "^2.2.9",
         "nikolaposa/version": "^4.1.0",
         "ocramius/package-versions": "^2.5.1",
-        "roave/better-reflection": "^5.2.0",
+        "roave/better-reflection": "^5.3.0",
         "symfony/console": "^5.4.5"
     },
     "license": "MIT",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae7d8dc1e7f6cc719393a69033a395d8",
+    "content-hash": "3b781bb51ea11fda348a8879105de32f",
     "packages": [
         {
             "name": "azjezz/psl",
@@ -1160,16 +1160,16 @@
         },
         {
             "name": "roave/better-reflection",
-            "version": "5.2.0",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/BetterReflection.git",
-                "reference": "661ef079e23fee517b5eccd12bbd582de0903263"
+                "reference": "e2e9062ec1c0f6bc95ee29a5d4277ecb708aaf4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/BetterReflection/zipball/661ef079e23fee517b5eccd12bbd582de0903263",
-                "reference": "661ef079e23fee517b5eccd12bbd582de0903263",
+                "url": "https://api.github.com/repos/Roave/BetterReflection/zipball/e2e9062ec1c0f6bc95ee29a5d4277ecb708aaf4d",
+                "reference": "e2e9062ec1c0f6bc95ee29a5d4277ecb708aaf4d",
                 "shasum": ""
             },
             "require": {
@@ -1184,10 +1184,10 @@
             },
             "require-dev": {
                 "doctrine/coding-standard": "^9.0.0",
-                "phpstan/phpstan": "^1.4.6",
+                "phpstan/phpstan": "^1.4.10",
                 "phpunit/phpunit": "^9.5.13",
-                "roave/infection-static-analysis-plugin": "^1.17.0",
-                "vimeo/psalm": "^4.21"
+                "roave/infection-static-analysis-plugin": "^1.18.0",
+                "vimeo/psalm": "^4.22"
             },
             "suggest": {
                 "composer/composer": "Required to use the ComposerSourceLocator"
@@ -1227,9 +1227,9 @@
             "description": "Better Reflection - an improved code reflection API",
             "support": {
                 "issues": "https://github.com/Roave/BetterReflection/issues",
-                "source": "https://github.com/Roave/BetterReflection/tree/5.2.0"
+                "source": "https://github.com/Roave/BetterReflection/tree/5.3.0"
             },
-            "time": "2022-02-27T19:04:55+00:00"
+            "time": "2022-03-22T15:47:53+00:00"
         },
         {
             "name": "roave/signature",

--- a/src/Command/AssertBackwardsCompatible.php
+++ b/src/Command/AssertBackwardsCompatible.php
@@ -33,41 +33,19 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class AssertBackwardsCompatible extends Command
 {
-    private PerformCheckoutOfRevision $git;
-
-    private ComposerInstallationReflectorFactory $makeComposerInstallationReflector;
-
-    private ParseRevision $parseRevision;
-
-    private GetVersionCollection $getVersions;
-
-    private PickVersionFromVersionCollection $pickFromVersion;
-
-    private LocateDependencies $locateDependencies;
-
-    private CompareApi $compareApi;
-
     /**
      * @throws LogicException
      */
     public function __construct(
-        PerformCheckoutOfRevision $git,
-        ComposerInstallationReflectorFactory $makeComposerInstallationReflector,
-        ParseRevision $parseRevision,
-        GetVersionCollection $getVersions,
-        PickVersionFromVersionCollection $pickFromVersion,
-        LocateDependencies $locateDependencies,
-        CompareApi $compareApi
+        private PerformCheckoutOfRevision $git,
+        private ComposerInstallationReflectorFactory $makeComposerInstallationReflector,
+        private ParseRevision $parseRevision,
+        private GetVersionCollection $getVersions,
+        private PickVersionFromVersionCollection $pickFromVersion,
+        private LocateDependencies $locateDependencies,
+        private CompareApi $compareApi
     ) {
         parent::__construct();
-
-        $this->git                               = $git;
-        $this->makeComposerInstallationReflector = $makeComposerInstallationReflector;
-        $this->parseRevision                     = $parseRevision;
-        $this->getVersions                       = $getVersions;
-        $this->pickFromVersion                   = $pickFromVersion;
-        $this->locateDependencies                = $locateDependencies;
-        $this->compareApi                        = $compareApi;
     }
 
     /**

--- a/src/LocateDependencies/LocateDependenciesViaComposer.php
+++ b/src/LocateDependencies/LocateDependenciesViaComposer.php
@@ -9,6 +9,7 @@ use Composer\Installer;
 use Psl;
 use Psl\Env;
 use Psl\Filesystem;
+use Roave\BackwardCompatibility\SourceLocator\ReplaceSourcePathOfLocatedSources;
 use Roave\BetterReflection\SourceLocator\Ast\Locator;
 use Roave\BetterReflection\SourceLocator\SourceStubber\ReflectionSourceStubber;
 use Roave\BetterReflection\SourceLocator\Type\AggregateSourceLocator;
@@ -55,9 +56,11 @@ final class LocateDependenciesViaComposer implements LocateDependencies
             $installer->run();
         }, $installationPath);
 
+        $astLocator = new ReplaceSourcePathOfLocatedSources($this->astLocator, $installationPath);
+
         return new AggregateSourceLocator([
-            new PhpInternalSourceLocator($this->astLocator, new ReflectionSourceStubber()),
-            (new MakeLocatorForInstalledJson())($installationPath, $this->astLocator),
+            new PhpInternalSourceLocator($astLocator, new ReflectionSourceStubber()),
+            (new MakeLocatorForInstalledJson())($installationPath, $astLocator),
         ]);
     }
 

--- a/src/LocateSources/LocateSourcesViaComposerJson.php
+++ b/src/LocateSources/LocateSourcesViaComposerJson.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BackwardCompatibility\LocateSources;
 
+use Roave\BackwardCompatibility\SourceLocator\ReplaceSourcePathOfLocatedSources;
 use Roave\BetterReflection\SourceLocator\Ast\Locator;
 use Roave\BetterReflection\SourceLocator\Type\Composer\Factory\MakeLocatorForComposerJson;
 use Roave\BetterReflection\SourceLocator\Type\SourceLocator;
@@ -19,6 +20,12 @@ final class LocateSourcesViaComposerJson implements LocateSources
 
     public function __invoke(string $installationPath): SourceLocator
     {
-        return (new MakeLocatorForComposerJson())($installationPath, $this->astLocator);
+        return (new MakeLocatorForComposerJson())(
+            $installationPath,
+            new ReplaceSourcePathOfLocatedSources(
+                $this->astLocator,
+                $installationPath
+            )
+        );
     }
 }

--- a/src/SourceLocator/LocatedSourceWithStrippedSourcesDirectory.php
+++ b/src/SourceLocator/LocatedSourceWithStrippedSourcesDirectory.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BackwardCompatibility\SourceLocator;
+
+use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
+
+/** @internal */
+final class LocatedSourceWithStrippedSourcesDirectory extends LocatedSource
+{
+    public function __construct(
+        private LocatedSource $next,
+        private string $sourcesDirectory
+    ) {
+    }
+
+    // @TODO test that all methods are covered (use reflection)
+    public function getSource(): string
+    {
+        return $this->next->getSource();
+    }
+
+    public function getName(): ?string
+    {
+        return $this->next->getName();
+    }
+
+    public function getFileName(): ?string
+    {
+        $fileName = $this->next->getFileName();
+
+        if (null === $fileName || ! str_starts_with($fileName, $this->sourcesDirectory)) {
+            return $fileName;
+        }
+
+        return substr_replace($fileName, '', 0, strlen($this->sourcesDirectory));
+    }
+
+    public function isInternal(): bool
+    {
+        return $this->next->isInternal();
+    }
+
+    public function getExtensionName(): ?string
+    {
+        return $this->next->getExtensionName();
+    }
+
+    public function isEvaled(): bool
+    {
+        return $this->next->isEvaled();
+    }
+
+    public function getAliasName(): ?string
+    {
+        return $this->next->getAliasName();
+    }
+}

--- a/src/SourceLocator/LocatedSourceWithStrippedSourcesDirectory.php
+++ b/src/SourceLocator/LocatedSourceWithStrippedSourcesDirectory.php
@@ -6,6 +6,10 @@ namespace Roave\BackwardCompatibility\SourceLocator;
 
 use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
 
+use function str_starts_with;
+use function strlen;
+use function substr_replace;
+
 /** @internal */
 final class LocatedSourceWithStrippedSourcesDirectory extends LocatedSource
 {
@@ -15,7 +19,6 @@ final class LocatedSourceWithStrippedSourcesDirectory extends LocatedSource
     ) {
     }
 
-    // @TODO test that all methods are covered (use reflection)
     public function getSource(): string
     {
         return $this->next->getSource();
@@ -30,7 +33,7 @@ final class LocatedSourceWithStrippedSourcesDirectory extends LocatedSource
     {
         $fileName = $this->next->getFileName();
 
-        if (null === $fileName || ! str_starts_with($fileName, $this->sourcesDirectory)) {
+        if ($fileName === null || ! str_starts_with($fileName, $this->sourcesDirectory)) {
             return $fileName;
         }
 

--- a/src/SourceLocator/ReplaceSourcePathOfLocatedSources.php
+++ b/src/SourceLocator/ReplaceSourcePathOfLocatedSources.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BackwardCompatibility\SourceLocator;
+
+use Roave\BetterReflection\Identifier\Identifier;
+use Roave\BetterReflection\Identifier\IdentifierType;
+use Roave\BetterReflection\Reflection\Reflection;
+use Roave\BetterReflection\Reflector\Reflector;
+use Roave\BetterReflection\SourceLocator\Ast\Locator;
+use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
+
+/** @internal */
+final class ReplaceSourcePathOfLocatedSources extends Locator
+{
+    public function __construct(
+        private Locator $next,
+        private string $sourcesDirectory
+    ) {
+    }
+
+    // @TODO test that all methods are covered (use reflection)
+    /** {@inheritDoc} */
+    public function findReflection(
+        Reflector $reflector,
+        LocatedSource $locatedSource,
+        Identifier $identifier,
+    ): Reflection {
+        return $this->next->findReflection(
+            $reflector,
+            new LocatedSourceWithStrippedSourcesDirectory($locatedSource, $this->sourcesDirectory),
+            $identifier
+        );
+    }
+
+    /** {@inheritDoc} */
+    public function findReflectionsOfType(
+        Reflector $reflector,
+        LocatedSource $locatedSource,
+        IdentifierType $identifierType,
+    ): array {
+        return $this->next->findReflectionsOfType(
+            $reflector,
+            new LocatedSourceWithStrippedSourcesDirectory($locatedSource, $this->sourcesDirectory),
+            $identifierType
+        );
+    }
+}

--- a/src/SourceLocator/ReplaceSourcePathOfLocatedSources.php
+++ b/src/SourceLocator/ReplaceSourcePathOfLocatedSources.php
@@ -20,7 +20,6 @@ final class ReplaceSourcePathOfLocatedSources extends Locator
     ) {
     }
 
-    // @TODO test that all methods are covered (use reflection)
     /** {@inheritDoc} */
     public function findReflection(
         Reflector $reflector,

--- a/test/e2e/Command/AssertBackwardsCompatibleTest.php
+++ b/test/e2e/Command/AssertBackwardsCompatibleTest.php
@@ -43,6 +43,8 @@ interface C {}
 
 final class TheClass
 {
+    public const UNCHANGED_CONSTANT = __DIR__;
+
     public function method(A $a)
     {
     }
@@ -61,6 +63,8 @@ interface C {}
 
 final class TheClass
 {
+    public const UNCHANGED_CONSTANT = __DIR__;
+
     public function method(B $a)
     {
     }
@@ -79,6 +83,8 @@ interface C {}
 
 final class TheClass
 {
+    public const UNCHANGED_CONSTANT = __DIR__;
+
     public function method(C $a)
     {
     }
@@ -98,6 +104,8 @@ interface C {}
 
 final class TheClass
 {
+    public const UNCHANGED_CONSTANT = __DIR__;
+
     public function method(A $a)
     {
     }

--- a/test/unit/SourceLocator/LocatedSourceWithStrippedSourcesDirectoryTest.php
+++ b/test/unit/SourceLocator/LocatedSourceWithStrippedSourcesDirectoryTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoaveTest\BackwardCompatibility\SourceLocator;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+use Roave\BackwardCompatibility\SourceLocator\LocatedSourceWithStrippedSourcesDirectory;
+use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
+
+use function array_combine;
+use function array_filter;
+use function array_map;
+
+/**
+ * @covers \Roave\BackwardCompatibility\SourceLocator\LocatedSourceWithStrippedSourcesDirectory
+ */
+final class LocatedSourceWithStrippedSourcesDirectoryTest extends TestCase
+{
+    /** @dataProvider verifiedPaths */
+    public function testWillStripPrefixFilePathWhenLocatedSourceInConfiguredPath(
+        string $sourcePath,
+        string $strippedSourcesPath,
+        string $expectedPath
+    ): void {
+        $source = $this->createMock(LocatedSource::class);
+
+        $source
+            ->method('getFileName')
+            ->willReturn($sourcePath);
+
+        self::assertSame(
+            $expectedPath,
+            (new LocatedSourceWithStrippedSourcesDirectory($source, $strippedSourcesPath))
+                ->getFileName()
+        );
+    }
+    
+    /** @return non-empty-list<array{string, string, string}> */
+    public function verifiedPaths(): array
+    {
+        return [
+            ['/foo/bar.php', '/foo', '/bar.php'],
+            ['/foo/bar.php', '/foo/', 'bar.php'],
+            ['/foo/bar.php', '/baz', '/foo/bar.php'],
+            ['/foo/bar.php', '', '/foo/bar.php'],
+        ];
+    }
+    
+    public function testWillGetSourcesFromGivenLocatedSource(): void
+    {
+        self::assertSame(
+            'SOURCES!!!',
+            (new LocatedSourceWithStrippedSourcesDirectory(
+                new LocatedSource('SOURCES!!!', null, null),
+                '/some/source/directory'
+            ))->getSource()
+        );
+    }
+
+    public function testWillGetSourceNameFromGivenLocatedSource(): void
+    {
+        self::assertSame(
+            'NAME!!!',
+            (new LocatedSourceWithStrippedSourcesDirectory(
+                new LocatedSource('', 'NAME!!!', null),
+                '/some/source/directory'
+            ))->getName()
+        );
+    }
+
+    public function testWillReportInternalSourceFromGivenLocatedSource(): void
+    {
+        $nonInternalSource = $this->createMock(LocatedSource::class);
+        $internalSource    =  $this->createMock(LocatedSource::class);
+
+        $nonInternalSource
+            ->method('isInternal')
+            ->willReturn(false);
+
+        $internalSource
+            ->method('isInternal')
+            ->willReturn(true);
+        
+        self::assertFalse(
+            (new LocatedSourceWithStrippedSourcesDirectory(
+                $nonInternalSource,
+                '/some/source/directory'
+            ))->isInternal()
+        );
+        self::assertTrue(
+            (new LocatedSourceWithStrippedSourcesDirectory(
+                $internalSource,
+                '/some/source/directory'
+            ))->isInternal()
+        );
+    }
+
+    public function testWillGetExtensionNameFromGivenLocatedSource(): void
+    {
+        $extensionSource = $this->createMock(LocatedSource::class);
+        
+        $extensionSource
+            ->method('getExtensionName')
+            ->willReturn('the-extension');
+        
+        self::assertSame(
+            'the-extension',
+            (new LocatedSourceWithStrippedSourcesDirectory($extensionSource, '/some/source/directory'))
+                ->getExtensionName()
+        );
+    }
+
+    public function testWillReportEvaledSourceFromGivenLocatedSource(): void
+    {
+        $nonEvaledSource = $this->createMock(LocatedSource::class);
+        $evaledSource    =  $this->createMock(LocatedSource::class);
+
+        $nonEvaledSource
+            ->method('isEvaled')
+            ->willReturn(false);
+
+        $evaledSource
+            ->method('isEvaled')
+            ->willReturn(true);
+
+        self::assertFalse(
+            (new LocatedSourceWithStrippedSourcesDirectory(
+                $nonEvaledSource,
+                '/some/source/directory'
+            ))->isEvaled()
+        );
+        self::assertTrue(
+            (new LocatedSourceWithStrippedSourcesDirectory(
+                $evaledSource,
+                '/some/source/directory'
+            ))->isEvaled()
+        );
+    }
+
+    public function testWillGetAliasNameFromGivenLocatedSource(): void
+    {
+        $aliasedSource = $this->createMock(LocatedSource::class);
+
+        $aliasedSource
+            ->method('getAliasName')
+            ->willReturn('the-alias');
+
+        self::assertSame(
+            'the-alias',
+            (new LocatedSourceWithStrippedSourcesDirectory($aliasedSource, '/some/source/directory'))
+                ->getAliasName()
+        );
+    }
+
+    /**
+     * This test makes sure that we didn't forget to override any public API of {@see LocatedSource}
+     *
+     * @dataProvider methodsDeclaredByLocatedSource
+     */
+    public function testAllMethodsOfOriginalLocatedSourceAreOverridden(ReflectionMethod $method): void
+    {
+        self::assertSame(
+            LocatedSourceWithStrippedSourcesDirectory::class,
+            $method
+                ->getDeclaringClass()
+                ->getName(),
+            'Method is re-declared in the subclass'
+        );
+    }
+    
+    /** @return array<string, array{ReflectionMethod}> */
+    public function methodsDeclaredByLocatedSource(): array
+    {
+        $methods = array_filter(
+            (new ReflectionClass(LocatedSourceWithStrippedSourcesDirectory::class))
+                ->getMethods(),
+            static fn (ReflectionMethod $method): bool => $method->isPublic() && ! $method->isStatic()
+        );
+        
+        return array_combine(
+            array_map(static fn (ReflectionMethod $method): string => $method->getName(), $methods),
+            array_map(static fn (ReflectionMethod $method): array => [$method], $methods),
+        );
+    }
+}

--- a/test/unit/SourceLocator/ReplaceSourcePathOfLocatedSourcesTest.php
+++ b/test/unit/SourceLocator/ReplaceSourcePathOfLocatedSourcesTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoaveTest\BackwardCompatibility\SourceLocator;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+use Roave\BackwardCompatibility\SourceLocator\LocatedSourceWithStrippedSourcesDirectory;
+use Roave\BackwardCompatibility\SourceLocator\ReplaceSourcePathOfLocatedSources;
+use Roave\BetterReflection\Identifier\Identifier;
+use Roave\BetterReflection\Identifier\IdentifierType;
+use Roave\BetterReflection\Reflection\Reflection;
+use Roave\BetterReflection\Reflector\Reflector;
+use Roave\BetterReflection\SourceLocator\Ast\Locator;
+use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
+
+use function array_combine;
+use function array_filter;
+use function array_map;
+
+/**
+ * @covers \Roave\BackwardCompatibility\SourceLocator\ReplaceSourcePathOfLocatedSources
+ */
+final class ReplaceSourcePathOfLocatedSourcesTest extends TestCase
+{
+    public function testWillWrapFoundReflection(): void
+    {
+        $reflection = $this->createMock(Reflection::class);
+        $next       = $this->createMock(Locator::class);
+        $reflector  = $this->createMock(Reflector::class);
+        $source     = $this->createMock(LocatedSource::class);
+        $identifier = new Identifier('find-me', new IdentifierType(IdentifierType::IDENTIFIER_CLASS));
+        
+        $next->expects(self::once())
+            ->method('findReflection')
+            ->with(
+                $reflector,
+                self::equalTo(new LocatedSourceWithStrippedSourcesDirectory($source, '/foo')),
+                $identifier
+            )
+            ->willReturn($reflection);
+        
+        self::assertSame(
+            $reflection,
+            (new ReplaceSourcePathOfLocatedSources($next, '/foo'))
+                ->findReflection($reflector, $source, $identifier)
+        );
+    }
+
+    public function testWillWrapFoundReflectionsOfType(): void
+    {
+        $reflection     = $this->createMock(Reflection::class);
+        $next           = $this->createMock(Locator::class);
+        $reflector      = $this->createMock(Reflector::class);
+        $source         = $this->createMock(LocatedSource::class);
+        $identifierType = new IdentifierType(IdentifierType::IDENTIFIER_CLASS);
+
+        $next->expects(self::once())
+            ->method('findReflectionsOfType')
+            ->with(
+                $reflector,
+                self::equalTo(new LocatedSourceWithStrippedSourcesDirectory($source, '/foo')),
+                $identifierType
+            )
+            ->willReturn([$reflection]);
+
+        self::assertSame(
+            [$reflection],
+            (new ReplaceSourcePathOfLocatedSources($next, '/foo'))
+                ->findReflectionsOfType($reflector, $source, $identifierType)
+        );
+    }
+
+    /**
+     * This test makes sure that we didn't forget to override any public API of {@see ReplaceSourcePathOfLocatedSources}
+     *
+     * @dataProvider methodsDeclaredByReplaceSourcePathOfLocatedSources
+     */
+    public function testAllMethodsOfBaseClassAreOverridden(ReflectionMethod $method): void
+    {
+        self::assertSame(
+            ReplaceSourcePathOfLocatedSources::class,
+            $method
+                ->getDeclaringClass()
+                ->getName(),
+            'Method is re-declared in the subclass'
+        );
+    }
+
+    /** @return array<string, array{ReflectionMethod}> */
+    public function methodsDeclaredByReplaceSourcePathOfLocatedSources(): array
+    {
+        $methods = array_filter(
+            (new ReflectionClass(ReplaceSourcePathOfLocatedSources::class))
+                ->getMethods(),
+            static fn (ReflectionMethod $method): bool => $method->isPublic() && ! $method->isStatic()
+        );
+
+        return array_combine(
+            array_map(static fn (ReflectionMethod $method): string => $method->getName(), $methods),
+            array_map(static fn (ReflectionMethod $method): array => [$method], $methods),
+        );
+    }
+}


### PR DESCRIPTION
This fails due to `CompileNodeToValue()` internally using `realpath()` and `dirname()` operations, which both depend
on the current filesystem: as it currently stands, this requires an improvement of `roave/better-reflection` first.

Also, `ReplaceSourcePathOfLocatedSources` and `LocatedSourceWithStrippedSourcesDirectory` are extending `@internal`
symbols, so we may want to first make these symbols public in `roave/better-reflection`, to avoid the BC boundary to
become too relaxed, and therefore causing crashes if we (rightfully) decide to change `roave/better-reflection` internals.

Fixes #400
Fixes #410

## TODO

 * [x] https://github.com/Roave/BetterReflection/issues/1043