### PR TITLE
Disable GPG signing for commit operations

### DIFF
--- a/test/e2e/Command/AssertBackwardsCompatibleTest.php
+++ b/test/e2e/Command/AssertBackwardsCompatibleTest.php
@@ -142,13 +142,13 @@ PHP,
         File\write($this->sourcesRepository . '/composer.json', self::COMPOSER_MANIFEST);
 
         Shell\execute('git', ['add', '-A'], $this->sourcesRepository);
-        Shell\execute('git', ['commit', '-am', 'Initial commit with composer manifest'], $this->sourcesRepository);
+        Shell\execute('git', ['commit', '--no-gpg-sign', '-am', 'Initial commit with composer manifest'], $this->sourcesRepository);
 
         foreach (self::CLASS_VERSIONS as $key => $classCode) {
             File\write($this->sourcesRepository . '/src/TheClass.php', $classCode);
 
             Shell\execute('git', ['add', '-A'], $this->sourcesRepository);
-            Shell\execute('git', ['commit', '-am', Str\format('Class sources v%d', $key + 1)], $this->sourcesRepository);
+            Shell\execute('git', ['commit', '--no-gpg-sign', '-am', Str\format('Class sources v%d', $key + 1)], $this->sourcesRepository);
             $this->versions[$key] = Str\trim(Shell\execute('git', ['rev-parse', 'HEAD'], $this->sourcesRepository));
         }
     }

--- a/test/unit/Git/GetVersionCollectionFromGitRepositoryTest.php
+++ b/test/unit/Git/GetVersionCollectionFromGitRepositoryTest.php
@@ -30,7 +30,7 @@ final class GetVersionCollectionFromGitRepositoryTest extends TestCase
         Shell\execute('git', ['config', 'user.name', 'Me Again'], $tmpGitRepo);
         File\write($tmpGitRepo . '/test', SecureRandom\string(8));
         Shell\execute('git', ['add', '.'], $tmpGitRepo);
-        Shell\execute('git', ['commit', '-m', '"whatever"'], $tmpGitRepo);
+        Shell\execute('git', ['commit', '--no-gpg-sign', '-m', '"whatever"'], $tmpGitRepo);
 
         $this->repoPath = CheckedOutRepository::fromPath($tmpGitRepo);
     }

--- a/test/unit/Git/GitCheckoutRevisionToTemporaryPathTest.php
+++ b/test/unit/Git/GitCheckoutRevisionToTemporaryPathTest.php
@@ -63,7 +63,7 @@ final class GitCheckoutRevisionToTemporaryPathTest extends TestCase
         Shell\execute('git', ['init'], $repoPath);
         Shell\execute('git', ['config', 'user.email', 'me@example.com'], $repoPath);
         Shell\execute('git', ['config', 'user.name', 'Mr Magoo'], $repoPath);
-        Shell\execute('git', ['commit', '-m', 'initial commit', '--allow-empty'], $repoPath);
+        Shell\execute('git', ['commit', '-m', 'initial commit', '--allow-empty', '--no-gpg-sign'], $repoPath);
 
         $firstCommit = Revision::fromSha1(
             Shell\execute('git', ['rev-parse', 'HEAD'], $repoPath),
@@ -72,7 +72,7 @@ final class GitCheckoutRevisionToTemporaryPathTest extends TestCase
         File\write($repoPath . '/a-file.txt', 'file contents');
 
         Shell\execute('git', ['add', 'a-file.txt'], $repoPath);
-        Shell\execute('git', ['commit', '-m', 'second commit', '--allow-empty'], $repoPath);
+        Shell\execute('git', ['commit', '-m', 'second commit', '--allow-empty', '--no-gpg-sign'], $repoPath);
 
         $secondCommit = Revision::fromSha1(
             Shell\execute('git', ['rev-parse', 'HEAD'], $repoPath),


### PR DESCRIPTION
Tests are broken for everyone who use GPG to sings commits by default.