### PR TITLE
Always cleanup the temporary directory in github actions formatter test even if the assertion fails.

### DIFF
--- a/test/unit/Formatter/GithubActionsFormatterTest.php
+++ b/test/unit/Formatter/GithubActionsFormatterTest.php
@@ -51,6 +51,8 @@ final class GithubActionsFormatterTest extends TestCase
                 ->onColumn(20),
         ));
 
+        Filesystem\delete_directory($temporaryLocation, true);
+
         self::assertEquals(
             <<<'OUTPUT'
 ::error::foo
@@ -65,7 +67,5 @@ OUTPUT
             ,
             $output->fetch(),
         );
-
-        Filesystem\delete_directory($temporaryLocation, true);
     }
 }


### PR DESCRIPTION
Noticed while working on https://github.com/Roave/BackwardCompatibilityCheck/pull/654

if the assertion fails, it will throw an exception and as a result not clean up the temporary directory created in the test case, and potentially pollute other test runs.