### PR TITLE
Gracefully handle scenarios where code start/end line cannot be found

### DIFF
--- a/src/Change.php
+++ b/src/Change.php
@@ -74,7 +74,7 @@ final class Change
     /** @internal */
     public function withFilePositionsIfNotAlreadySet(
         string|null $file,
-        int $line,
+        int|null $line,
         int|null $column,
     ): self {
         $instance = clone $this;

--- a/src/DetectChanges/BCBreak/ClassBased/MultipleChecksOnAClass.php
+++ b/src/DetectChanges/BCBreak/ClassBased/MultipleChecksOnAClass.php
@@ -6,7 +6,7 @@ namespace Roave\BackwardCompatibility\DetectChanges\BCBreak\ClassBased;
 
 use Roave\BackwardCompatibility\Change;
 use Roave\BackwardCompatibility\Changes;
-use Roave\BackwardCompatibility\Formatter\SymbolStartColumn;
+use Roave\BackwardCompatibility\Formatter\SymbolStart;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 
 final class MultipleChecksOnAClass implements ClassBased
@@ -29,7 +29,7 @@ final class MultipleChecksOnAClass implements ClassBased
     {
         $toFile   = $toClass->getFileName();
         $toLine   = $toClass->getStartLine();
-        $toColumn = SymbolStartColumn::get($toClass);
+        $toColumn = SymbolStart::getColumn($toClass);
 
         foreach ($this->checks as $check) {
             foreach ($check($fromClass, $toClass) as $change) {

--- a/src/DetectChanges/BCBreak/ClassConstantBased/MultipleChecksOnAClassConstant.php
+++ b/src/DetectChanges/BCBreak/ClassConstantBased/MultipleChecksOnAClassConstant.php
@@ -6,7 +6,7 @@ namespace Roave\BackwardCompatibility\DetectChanges\BCBreak\ClassConstantBased;
 
 use Roave\BackwardCompatibility\Change;
 use Roave\BackwardCompatibility\Changes;
-use Roave\BackwardCompatibility\Formatter\SymbolStartColumn;
+use Roave\BackwardCompatibility\Formatter\SymbolStart;
 use Roave\BetterReflection\Reflection\ReflectionClassConstant;
 
 final class MultipleChecksOnAClassConstant implements ClassConstantBased
@@ -28,7 +28,7 @@ final class MultipleChecksOnAClassConstant implements ClassConstantBased
     private function multipleChecks(ReflectionClassConstant $fromConstant, ReflectionClassConstant $toConstant): iterable
     {
         $toLine   = $toConstant->getStartLine();
-        $toColumn = SymbolStartColumn::get($toConstant);
+        $toColumn = SymbolStart::getColumn($toConstant);
         $toFile   = $toConstant->getDeclaringClass()
             ->getFileName();
 

--- a/src/DetectChanges/BCBreak/FunctionBased/MultipleChecksOnAFunction.php
+++ b/src/DetectChanges/BCBreak/FunctionBased/MultipleChecksOnAFunction.php
@@ -6,7 +6,7 @@ namespace Roave\BackwardCompatibility\DetectChanges\BCBreak\FunctionBased;
 
 use Roave\BackwardCompatibility\Change;
 use Roave\BackwardCompatibility\Changes;
-use Roave\BackwardCompatibility\Formatter\SymbolStartColumn;
+use Roave\BackwardCompatibility\Formatter\SymbolStart;
 use Roave\BetterReflection\Reflection\ReflectionFunction;
 use Roave\BetterReflection\Reflection\ReflectionMethod;
 
@@ -40,8 +40,8 @@ final class MultipleChecksOnAFunction implements FunctionBased
         ReflectionMethod|ReflectionFunction $toFunction,
     ): iterable {
         $toFile   = $toFunction->getFileName();
-        $toLine   = $toFunction->getStartLine();
-        $toColumn = SymbolStartColumn::get($toFunction);
+        $toLine   = SymbolStart::getLine($toFunction);
+        $toColumn = SymbolStart::getColumn($toFunction);
 
         foreach ($this->checks as $check) {
             foreach ($check($fromFunction, $toFunction) as $change) {

--- a/src/DetectChanges/BCBreak/InterfaceBased/MultipleChecksOnAnInterface.php
+++ b/src/DetectChanges/BCBreak/InterfaceBased/MultipleChecksOnAnInterface.php
@@ -6,7 +6,7 @@ namespace Roave\BackwardCompatibility\DetectChanges\BCBreak\InterfaceBased;
 
 use Roave\BackwardCompatibility\Change;
 use Roave\BackwardCompatibility\Changes;
-use Roave\BackwardCompatibility\Formatter\SymbolStartColumn;
+use Roave\BackwardCompatibility\Formatter\SymbolStart;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 
 final class MultipleChecksOnAnInterface implements InterfaceBased
@@ -29,7 +29,7 @@ final class MultipleChecksOnAnInterface implements InterfaceBased
     {
         $toFile   = $toInterface->getFileName();
         $toLine   = $toInterface->getStartLine();
-        $toColumn = SymbolStartColumn::get($toInterface);
+        $toColumn = SymbolStart::getColumn($toInterface);
 
         foreach ($this->checks as $check) {
             foreach ($check($fromInterface, $toInterface) as $change) {

--- a/src/DetectChanges/BCBreak/MethodBased/MultipleChecksOnAMethod.php
+++ b/src/DetectChanges/BCBreak/MethodBased/MultipleChecksOnAMethod.php
@@ -6,7 +6,7 @@ namespace Roave\BackwardCompatibility\DetectChanges\BCBreak\MethodBased;
 
 use Roave\BackwardCompatibility\Change;
 use Roave\BackwardCompatibility\Changes;
-use Roave\BackwardCompatibility\Formatter\SymbolStartColumn;
+use Roave\BackwardCompatibility\Formatter\SymbolStart;
 use Roave\BetterReflection\Reflection\ReflectionMethod;
 
 final class MultipleChecksOnAMethod implements MethodBased
@@ -28,8 +28,8 @@ final class MultipleChecksOnAMethod implements MethodBased
     private function multipleChecks(ReflectionMethod $fromMethod, ReflectionMethod $toMethod): iterable
     {
         $toFile   = $toMethod->getFileName();
-        $toLine   = $toMethod->getStartLine();
-        $toColumn = SymbolStartColumn::get($toMethod);
+        $toLine   = SymbolStart::getLine($toMethod);
+        $toColumn = SymbolStart::getColumn($toMethod);
 
         foreach ($this->checks as $check) {
             foreach ($check($fromMethod, $toMethod) as $change) {

--- a/src/DetectChanges/BCBreak/PropertyBased/MultipleChecksOnAProperty.php
+++ b/src/DetectChanges/BCBreak/PropertyBased/MultipleChecksOnAProperty.php
@@ -6,7 +6,7 @@ namespace Roave\BackwardCompatibility\DetectChanges\BCBreak\PropertyBased;
 
 use Roave\BackwardCompatibility\Change;
 use Roave\BackwardCompatibility\Changes;
-use Roave\BackwardCompatibility\Formatter\SymbolStartColumn;
+use Roave\BackwardCompatibility\Formatter\SymbolStart;
 use Roave\BetterReflection\Reflection\ReflectionProperty;
 
 final class MultipleChecksOnAProperty implements PropertyBased
@@ -27,8 +27,8 @@ final class MultipleChecksOnAProperty implements PropertyBased
     /** @return iterable<int, Change> */
     private function multipleChecks(ReflectionProperty $fromProperty, ReflectionProperty $toProperty): iterable
     {
-        $toLine   = $toProperty->getStartLine();
-        $toColumn = SymbolStartColumn::get($toProperty);
+        $toLine   = SymbolStart::getLine($toProperty);
+        $toColumn = SymbolStart::getColumn($toProperty);
         $toFile   = $toProperty->getImplementingClass()
             ->getFileName();
 

--- a/src/DetectChanges/BCBreak/TraitBased/MultipleChecksOnATrait.php
+++ b/src/DetectChanges/BCBreak/TraitBased/MultipleChecksOnATrait.php
@@ -6,7 +6,7 @@ namespace Roave\BackwardCompatibility\DetectChanges\BCBreak\TraitBased;
 
 use Roave\BackwardCompatibility\Change;
 use Roave\BackwardCompatibility\Changes;
-use Roave\BackwardCompatibility\Formatter\SymbolStartColumn;
+use Roave\BackwardCompatibility\Formatter\SymbolStart;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 
 final class MultipleChecksOnATrait implements TraitBased
@@ -29,7 +29,7 @@ final class MultipleChecksOnATrait implements TraitBased
     {
         $toFile   = $toTrait->getFileName();
         $toLine   = $toTrait->getStartLine();
-        $toColumn = SymbolStartColumn::get($toTrait);
+        $toColumn = SymbolStart::getColumn($toTrait);
 
         foreach ($this->checks as $check) {
             foreach ($check($fromTrait, $toTrait) as $change) {

--- a/src/Formatter/SymbolStart.php
+++ b/src/Formatter/SymbolStart.php
@@ -13,7 +13,7 @@ use Roave\BetterReflection\Reflection\ReflectionProperty;
 use RuntimeException;
 
 /** @internal */
-final class SymbolStartColumn
+final class SymbolStart
 {
     /**
      * Determines the column at which a given symbol starts, if able to do so.
@@ -24,11 +24,30 @@ final class SymbolStartColumn
      * declared via custom AST added by `roave/better-reflection` post-parsing (such as `__toString()`
      * in {@see \Stringable::__toString()}).
      */
-    public static function get(
+    public static function getColumn(
         ReflectionFunction|ReflectionMethod|ReflectionProperty|ReflectionClass|ReflectionClassConstant|ReflectionConstant $symbol,
     ): int|null {
         try {
             return $symbol->getStartColumn();
+        } catch (RuntimeException) {
+            return null;
+        }
+    }
+
+    /**
+     * Determines the line at which a given symbol starts, if able to do so.
+     *
+     * Mostly exists because the reflection logic may be configured to skip parsing/collecting
+     * AST node exact positions, and because some sources (especially if stubbed from PHP core)
+     * could have trouble identifying the position of a symbol, given that some of them are
+     * declared via custom AST added by `roave/better-reflection` post-parsing (such as `__toString()`
+     * in {@see \Stringable::__toString()}).
+     */
+    public static function getLine(
+        ReflectionFunction|ReflectionMethod|ReflectionProperty|ReflectionClass|ReflectionClassConstant|ReflectionConstant $symbol,
+    ): int|null {
+        try {
+            return $symbol->getStartLine();
         } catch (RuntimeException) {
             return null;
         }


### PR DESCRIPTION
Coming from https://github.com/Roave/BetterReflection/issues/1309.

First draft of handling the code location missing error. First, only in those places needed to handle the issue provided in the linked issue of BetterReflection. ~~But i think the other one should be updated too, right?~~

The other cases all dont throw since `ReflectionClass`, `ReflectionConstant` and `ReflectionClassConstant` dont throw at `getStartLine`.