### PR TITLE
Add contravariant test which fails due to missing in the from part

### DIFF
--- a/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterTypeContravarianceChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterTypeContravarianceChangedTest.php
@@ -88,6 +88,13 @@ namespace N4 {
        function changed2($a, $b) {}
    }
 }
+
+namespace N5 {
+    interface A {}
+    class C {
+        public function changed(A $a) {}
+    }
+}
 PHP
             ,
             $astLocator,
@@ -125,6 +132,14 @@ namespace N4 {
        static function changed1(int $a, int $b) {}
        function changed2(int $a, int $b) {}
    }
+}
+
+namespace N5 {
+    interface A extends B {}
+    interface B {}
+    class C {
+        public function changed(B $a) {}
+    }
 }
 PHP
             ,
@@ -184,6 +199,11 @@ PHP
                         '[BC] CHANGED: The parameter $a of N4\C#changed2() changed from no type to a non-contravariant int',
                         '[BC] CHANGED: The parameter $b of N4\C#changed2() changed from no type to a non-contravariant int',
                     ],
+                ],
+                'N5\C#changed'  => [
+                    self::getMethod($fromReflector->reflectClass('N5\C'), 'changed'),
+                    self::getMethod($toReflector->reflectClass('N5\C'), 'changed'),
+                    [],
                 ],
             ],
         );


### PR DESCRIPTION
We have a situation right now where we want to enable the use to use the psr-20 clock interface. Beforehand we already introduced our own `ClockInterface` with the exact api the psr-20 one would have. And now, since it was released, we wanted to get rid of our own interface from our internal code but still providing it. So our interface now extends from the psr-20 one and we changed a signature which required our interface to the new psr-20 interface. In my opinion this should be ok, since the old interface is still allowed.

I provided a TestCase here to reproduce this. Also here as ref the PR where we want to achieve this: https://github.com/patchlevel/event-sourcing/pull/334