### PR TITLE
Fix #723 by ignoring BC issues on `@internal` methods of `final` classes

### DIFF
--- a/bin/roave-backward-compatibility-check.php
+++ b/bin/roave-backward-compatibility-check.php
@@ -208,7 +208,7 @@ use function file_exists;
                                 )),
                             )),
                             new ClassBased\SkipClassBasedErrors(new ClassBased\MethodChanged(
-                                new MethodBased\SkipMethodBasedErrors(new MethodBased\OnlyPublicMethodChanged(
+                                new MethodBased\SkipMethodBasedErrors(new MethodBased\OnlyPublicMethodChanged(new MethodBased\ExcludeInternalMethod(
                                     new MethodBased\MultipleChecksOnAMethod(
                                         new MethodBased\SkipMethodBasedErrors(new MethodBased\MethodBecameFinal()),
                                         new MethodBased\SkipMethodBasedErrors(new MethodBased\MethodConcretenessChanged()),
@@ -226,7 +226,7 @@ use function file_exists;
                                             ),
                                         )),
                                     ),
-                                )),
+                                ))),
                             )),
                         ),
                     )),


### PR DESCRIPTION
Because the configuration for final and non-final classes is almost mirrored, this is a code duplication problem: the config is large and complex, and these things kinda happen.

Fixes #723.

Ref: https://github.com/Roave/BackwardCompatibilityCheck/issues/723#issuecomment-1360631860

Quoting:

> So, I tried it on `vimeo/psalm` with the patch you were referring to:
>
> ```shell
> ../../roave/BackwardCompatibilityCheck/bin/roave-backward-compatibility-check --from=origin/master --to=origin/pr/8961
> <SNIP>
> [BC] CHANGED: The number of required arguments for Psalm\Plugin\EventHandler\Event\StringInterpreterEvent#__construct() increased from 1 to 2
> [BC] CHANGED: The number of required arguments for Psalm\Plugin\EventHandler\Event\BeforeAddIssueEvent#__construct() increased from 2 to 3
> 2 backwards-incompatible changes detected
> ```
>
> I applied a config change:
>
> ```diff
> diff --git a/bin/roave-backward-compatibility-check.php b/bin/roave-backward-compatibility-check.php
> index 2edcf53..c261d6a 100644
> --- a/bin/roave-backward-compatibility-check.php
> +++ b/bin/roave-backward-compatibility-check.php
> @@ -208,7 +208,7 @@ use function file_exists;
>                                  )),
>                              )),
>                              new ClassBased\SkipClassBasedErrors(new ClassBased\MethodChanged(
> -                                new MethodBased\SkipMethodBasedErrors(new MethodBased\OnlyPublicMethodChanged(
> +                                new MethodBased\SkipMethodBasedErrors(new MethodBased\OnlyPublicMethodChanged(new MethodBased\ExcludeInternalMethod(
>                                      new MethodBased\MultipleChecksOnAMethod(
>                                          new MethodBased\SkipMethodBasedErrors(new MethodBased\MethodBecameFinal()),
>                                          new MethodBased\SkipMethodBasedErrors(new MethodBased\MethodConcretenessChanged()),
> @@ -226,7 +226,7 @@ use function file_exists;
>                                              ),
>                                          )),
>                                      ),
> -                                )),
> +                                ))),
>                              )),
>                          ),
>                      )),
> ```
>
> ```shell
> ../../roave/BackwardCompatibilityCheck/bin/roave-backward-compatibility-check --from=origin/master --to=origin/pr/8961
> <SNIP>
> No backwards-incompatible changes detected
> ```