### PR TITLE
Upgrade to PHPUnit v10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 phpstan.neon
 phpunit.xml
 phpcs.xml
-.phpunit.result.cache
+/.phpunit.cache

--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,8 +1,21 @@
 {
     "extensions": [
-        "bcmath"
+        "bcmath", "pcov"
     ],
     "ini": [
         "memory_limit=-1"
+    ],
+    "exclude": [
+        {"name": "Infection"}
+    ],
+    "additional_checks": [
+        {
+            "name": "Infection (PCOV)",
+            "job": {
+                "php": "@lowest",
+                "dependencies": "locked",
+                "command": "./vendor/bin/roave-infection-static-analysis-plugin"
+            }
+        }
     ]
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "doctrine/coding-standard": "^12.0.0",
         "estahn/phpunit-json-assertions": "^4.0",
         "php-standard-library/psalm-plugin": "^2.3.0",
-        "phpunit/phpunit": "^9.6.19",
+        "phpunit/phpunit": "^10.5.44",
         "psalm/plugin-phpunit": "^0.19.0",
         "roave/infection-static-analysis-plugin": "^1.35.0",
         "roave/security-advisories": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d50ffb829acec585f0193fb15c3624b1",
+    "content-hash": "4044c984df3464d5e8e83aafddf39fed",
     "packages": [
         {
             "name": "azjezz/psl",
@@ -3146,76 +3146,6 @@
             "time": "2024-12-07T21:18:45+00:00"
         },
         {
-            "name": "doctrine/instantiator",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.1"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^11",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.9.4",
-                "phpstan/phpstan-phpunit": "^1.3",
-                "phpunit/phpunit": "^9.5.27",
-                "vimeo/psalm": "^5.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "https://ocramius.github.io/"
-                }
-            ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-12-30T00:23:10+00:00"
-        },
-        {
             "name": "estahn/phpunit-json-assertions",
             "version": "v4.0.0",
             "source": {
@@ -4397,16 +4327,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.32",
+            "version": "10.1.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
-                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
                 "shasum": ""
             },
             "require": {
@@ -4414,18 +4344,18 @@
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^4.19.1 || ^5.1.0",
-                "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.6",
-                "phpunit/php-text-template": "^2.0.4",
-                "sebastian/code-unit-reverse-lookup": "^2.0.3",
-                "sebastian/complexity": "^2.0.3",
-                "sebastian/environment": "^5.1.5",
-                "sebastian/lines-of-code": "^1.0.4",
-                "sebastian/version": "^3.0.2",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "sebastian/code-unit-reverse-lookup": "^3.0.0",
+                "sebastian/complexity": "^3.2.0",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/lines-of-code": "^2.0.2",
+                "sebastian/version": "^4.0.1",
                 "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.6"
+                "phpunit/phpunit": "^10.1"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -4434,7 +4364,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "9.2.x-dev"
+                    "dev-main": "10.1.x-dev"
                 }
             },
             "autoload": {
@@ -4463,7 +4393,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
             },
             "funding": [
                 {
@@ -4471,32 +4401,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-22T04:23:01+00:00"
+            "time": "2024-08-22T04:31:57+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.6",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -4523,7 +4453,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
             },
             "funding": [
                 {
@@ -4531,28 +4462,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-02T12:48:52+00:00"
+            "time": "2023-08-31T06:24:48+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "3.1.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -4560,7 +4491,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -4586,7 +4517,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
             },
             "funding": [
                 {
@@ -4594,32 +4525,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:58:55+00:00"
+            "time": "2023-02-03T06:56:09+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "2.0.4",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -4645,7 +4576,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
             },
             "funding": [
                 {
@@ -4653,32 +4585,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T05:33:50+00:00"
+            "time": "2023-08-31T14:07:24+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "5.0.3",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -4704,7 +4636,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
             },
             "funding": [
                 {
@@ -4712,24 +4644,23 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:16:10+00:00"
+            "time": "2023-02-03T06:57:52+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.22",
+            "version": "10.5.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f80235cb4d3caa59ae09be3adf1ded27521d1a9c"
+                "reference": "1381c62769be4bb88fa4c5aec1366c7c66ca4f36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f80235cb4d3caa59ae09be3adf1ded27521d1a9c",
-                "reference": "f80235cb4d3caa59ae09be3adf1ded27521d1a9c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1381c62769be4bb88fa4c5aec1366c7c66ca4f36",
+                "reference": "1381c62769be4bb88fa4c5aec1366c7c66ca4f36",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -4739,27 +4670,26 @@
                 "myclabs/deep-copy": "^1.12.1",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
-                "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.32",
-                "phpunit/php-file-iterator": "^3.0.6",
-                "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.4",
-                "phpunit/php-timer": "^5.0.3",
-                "sebastian/cli-parser": "^1.0.2",
-                "sebastian/code-unit": "^1.0.8",
-                "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.6",
-                "sebastian/environment": "^5.1.5",
-                "sebastian/exporter": "^4.0.6",
-                "sebastian/global-state": "^5.0.7",
-                "sebastian/object-enumerator": "^4.0.4",
-                "sebastian/resource-operations": "^3.0.4",
-                "sebastian/type": "^3.2.1",
-                "sebastian/version": "^3.0.2"
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.1.16",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-invoker": "^4.0.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "phpunit/php-timer": "^6.0.0",
+                "sebastian/cli-parser": "^2.0.1",
+                "sebastian/code-unit": "^2.0.0",
+                "sebastian/comparator": "^5.0.3",
+                "sebastian/diff": "^5.1.1",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/exporter": "^5.1.2",
+                "sebastian/global-state": "^6.0.2",
+                "sebastian/object-enumerator": "^5.0.0",
+                "sebastian/recursion-context": "^5.0.0",
+                "sebastian/type": "^4.0.0",
+                "sebastian/version": "^4.0.1"
             },
             "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+                "ext-soap": "To be able to generate mocks based on WSDL files"
             },
             "bin": [
                 "phpunit"
@@ -4767,7 +4697,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.6-dev"
+                    "dev-main": "10.5-dev"
                 }
             },
             "autoload": {
@@ -4799,7 +4729,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.22"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.44"
             },
             "funding": [
                 {
@@ -4815,7 +4745,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-05T13:48:26+00:00"
+            "time": "2025-01-31T07:00:38+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -5927,28 +5857,28 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.2",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
-                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -5971,7 +5901,8 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
             },
             "funding": [
                 {
@@ -5979,32 +5910,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:27:43+00:00"
+            "time": "2024-03-02T07:12:49+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "1.0.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -6027,7 +5958,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
             },
             "funding": [
                 {
@@ -6035,32 +5966,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:08:54+00:00"
+            "time": "2023-02-03T06:58:43+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.3",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -6082,7 +6013,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
             },
             "funding": [
                 {
@@ -6090,34 +6021,36 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:30:19+00:00"
+            "time": "2023-02-03T06:59:15+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.8",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+                "reference": "a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e",
+                "reference": "a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/diff": "^4.0",
-                "sebastian/exporter": "^4.0"
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -6156,7 +6089,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.3"
             },
             "funding": [
                 {
@@ -6164,33 +6098,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T12:41:17+00:00"
+            "time": "2024-10-18T14:56:07+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.3",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+                "reference": "68ff824baeae169ec9f2137158ee529584553799"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
-                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.2-dev"
                 }
             },
             "autoload": {
@@ -6213,7 +6147,8 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
             },
             "funding": [
                 {
@@ -6221,33 +6156,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:19:30+00:00"
+            "time": "2023-12-21T08:37:17+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.6",
+            "version": "5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "symfony/process": "^4.2 || ^5"
+                "phpunit/phpunit": "^10.0",
+                "symfony/process": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -6279,7 +6214,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
             },
             "funding": [
                 {
@@ -6287,27 +6223,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:30:58+00:00"
+            "time": "2024-03-02T07:15:17+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.5",
+            "version": "6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -6315,7 +6251,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1-dev"
+                    "dev-main": "6.1-dev"
                 }
             },
             "autoload": {
@@ -6334,7 +6270,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "homepage": "https://github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -6342,7 +6278,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
             },
             "funding": [
                 {
@@ -6350,34 +6287,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:03:51+00:00"
+            "time": "2024-03-23T08:47:14+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.6",
+            "version": "5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72"
+                "reference": "955288482d97c19a372d3f31006ab3f37da47adf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/78c00df8f170e02473b682df15bfcdacc3d32d72",
-                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/955288482d97c19a372d3f31006ab3f37da47adf",
+                "reference": "955288482d97c19a372d3f31006ab3f37da47adf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/recursion-context": "^4.0"
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -6419,7 +6356,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.6"
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.2"
             },
             "funding": [
                 {
@@ -6427,38 +6365,35 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:33:00+00:00"
+            "time": "2024-03-02T07:17:12+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.7",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9"
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-uopz": "*"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -6477,13 +6412,14 @@
                 }
             ],
             "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
             "keywords": [
                 "global state"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.7"
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
             },
             "funding": [
                 {
@@ -6491,33 +6427,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:35:11+00:00"
+            "time": "2024-03-02T07:19:19+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.4",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
-                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -6540,7 +6476,8 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
             },
             "funding": [
                 {
@@ -6548,34 +6485,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:20:34+00:00"
+            "time": "2023-12-21T08:38:20+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "4.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -6597,7 +6534,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
             },
             "funding": [
                 {
@@ -6605,32 +6542,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:12:34+00:00"
+            "time": "2023-02-03T07:08:32+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "2.0.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -6652,7 +6589,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
             },
             "funding": [
                 {
@@ -6660,32 +6597,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:14:26+00:00"
+            "time": "2023-02-03T07:06:18+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.5",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/05909fb5bc7df4c52992396d0116aed689f93712",
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -6715,7 +6652,7 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.0"
             },
             "funding": [
                 {
@@ -6723,86 +6660,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:07:39+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "3.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
-                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "support": {
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-03-14T16:00:52+00:00"
+            "time": "2023-02-03T07:05:40+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -6825,7 +6708,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
             },
             "funding": [
                 {
@@ -6833,29 +6716,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:13:03+00:00"
+            "time": "2023-02-03T07:10:45+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "3.0.2",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -6878,7 +6761,7 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
             },
             "funding": [
                 {
@@ -6886,7 +6769,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:39:44+00:00"
+            "time": "2023-02-07T11:34:05+00:00"
         },
         {
             "name": "slevomat/coding-standard",

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -17,5 +17,5 @@
         "NotIdenticalNotEqual": false
     },
     "minMsi": 85.8,
-    "minCoveredMsi": 100
+    "minCoveredMsi": 95
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,9 +2,10 @@
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
     bootstrap="test/bootstrap.php"
     colors="true"
-    convertDeprecationsToExceptions="true"
+    cacheDirectory=".phpunit.cache"
 >
     <testsuites>
         <testsuite name="unit">
@@ -15,11 +16,11 @@
         </testsuite>
     </testsuites>
 
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
-            <directory suffix=".php">./src</directory>
+            <directory>./src</directory>
         </include>
-    </coverage>
+    </source>
 
     <php>
         <ini name="error_reporting" value="E_ALL"/>

--- a/test/e2e/Command/AssertBackwardsCompatibleTest.php
+++ b/test/e2e/Command/AssertBackwardsCompatibleTest.php
@@ -138,6 +138,8 @@ PHP,
         Shell\execute('git', ['init'], $this->sourcesRepository);
         Shell\execute('git', ['config', 'user.email', 'me@example.com'], $this->sourcesRepository);
         Shell\execute('git', ['config', 'user.name', 'Just Me'], $this->sourcesRepository);
+        Shell\execute('git', ['config', 'commit.gpgSign', 'false'], $this->sourcesRepository);
+        Shell\execute('git', ['config', 'tag.forceSignAnnotated', 'false'], $this->sourcesRepository);
 
         File\write($this->sourcesRepository . '/composer.json', self::COMPOSER_MANIFEST);
 

--- a/test/unit/Command/AssertBackwardsCompatibleTest.php
+++ b/test/unit/Command/AssertBackwardsCompatibleTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace RoaveTest\BackwardCompatibility\Command;
 
-use ArrayIterator;
+use LogicException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psl\Env;
@@ -21,7 +21,6 @@ use Roave\BackwardCompatibility\Factory\ComposerInstallationReflectorFactory;
 use Roave\BackwardCompatibility\Git\CheckedOutRepository;
 use Roave\BackwardCompatibility\Git\GetVersionCollection;
 use Roave\BackwardCompatibility\Git\ParseRevision;
-use Roave\BackwardCompatibility\Git\PerformCheckoutOfRevision;
 use Roave\BackwardCompatibility\Git\PickVersionFromVersionCollection;
 use Roave\BackwardCompatibility\Git\Revision;
 use Roave\BackwardCompatibility\LocateDependencies\LocateDependencies;
@@ -47,8 +46,7 @@ final class AssertBackwardsCompatibleTest extends TestCase
     private ConsoleOutputInterface $output;
     /** @var OutputInterface&MockObject */
     private OutputInterface $stdErr;
-    /** @var PerformCheckoutOfRevision&MockObject */
-    private PerformCheckoutOfRevision $performCheckout;
+    private PerformCheckoutOfRevisionForTests $performCheckout;
     /** @var ParseRevision&MockObject */
     private ParseRevision $parseRevision;
     /** @var GetVersionCollection&MockObject */
@@ -74,7 +72,7 @@ final class AssertBackwardsCompatibleTest extends TestCase
         $this->input              = $this->createMock(InputInterface::class);
         $this->output             = $this->createMock(ConsoleOutputInterface::class);
         $this->stdErr             = $this->createMock(OutputInterface::class);
-        $this->performCheckout    = $this->createMock(PerformCheckoutOfRevision::class);
+        $this->performCheckout    = new PerformCheckoutOfRevisionForTests();
         $this->parseRevision      = $this->createMock(ParseRevision::class);
         $this->getVersions        = $this->createMock(GetVersionCollection::class);
         $this->pickVersion        = $this->createMock(PickVersionFromVersionCollection::class);
@@ -138,45 +136,9 @@ final class AssertBackwardsCompatibleTest extends TestCase
             ['sources-path', 'src'],
         ]);
 
-        $this->performCheckout->expects(self::exactly(2))
-            ->method('checkout')
-            ->willReturnCallback(function (CheckedOutRepository $repository, Revision $sha) use ($fromSha, $toSha) {
-                $stringRevision = (string) $sha;
-
-                self::assertEquals($repository, $this->sourceRepository);
-                self::assertTrue($stringRevision === $fromSha || $stringRevision === $toSha);
-
-                return $this->sourceRepository;
-            });
-
-        $expectedCalls = new ArrayIterator([
-            $this->sourceRepository,
-            $this->sourceRepository,
-        ]);
-
-        $this->performCheckout->expects(self::exactly(2))
-            ->method('remove')
-            ->willReturnCallback(static function (CheckedOutRepository $repository) use ($expectedCalls): void {
-                self::assertTrue($expectedCalls->valid());
-
-                $expectedRepository = $expectedCalls->current();
-                $expectedCalls->next();
-
-                self::assertSame($expectedRepository, $repository);
-            });
-
-        $expectedShas = [
-            $fromSha => Revision::fromSha1($fromSha),
-            $toSha => Revision::fromSha1($toSha),
-        ];
-
         $this->parseRevision->expects(self::exactly(2))
             ->method('fromStringForRepository')
-            ->willReturnCallback(static function (string $sha) use ($expectedShas) {
-                self::assertArrayHasKey($sha, $expectedShas);
-
-                return $expectedShas[$sha];
-            });
+            ->willReturnCallback(Revision::fromSha1(...));
 
         $this
             ->locateDependencies
@@ -187,6 +149,7 @@ final class AssertBackwardsCompatibleTest extends TestCase
         $this->compareApi->expects(self::once())->method('__invoke')->willReturn(Changes::empty());
 
         self::assertSame(0, $this->compare->execute($this->input, $this->output));
+        self::assertSame(0, $this->performCheckout->nonRemovedRepositoryCount());
     }
 
     public function testExecuteWhenDevelopmentDependenciesAreRequested(): void
@@ -203,45 +166,9 @@ final class AssertBackwardsCompatibleTest extends TestCase
             ['sources-path', 'src'],
         ]);
 
-        $this->performCheckout->expects(self::exactly(2))
-            ->method('checkout')
-            ->willReturnCallback(function (CheckedOutRepository $repository, Revision $sha) use ($fromSha, $toSha) {
-                $stringRevision = (string) $sha;
-
-                self::assertEquals($repository, $this->sourceRepository);
-                self::assertTrue($stringRevision === $fromSha || $stringRevision === $toSha);
-
-                return $this->sourceRepository;
-            });
-
-        $expectedCalls = new ArrayIterator([
-            $this->sourceRepository,
-            $this->sourceRepository,
-        ]);
-
-        $this->performCheckout->expects(self::exactly(2))
-            ->method('remove')
-            ->willReturnCallback(static function (CheckedOutRepository $repository) use ($expectedCalls): void {
-                self::assertTrue($expectedCalls->valid());
-
-                $expectedRepository = $expectedCalls->current();
-                $expectedCalls->next();
-
-                self::assertSame($expectedRepository, $repository);
-            });
-
-        $expectedShas = [
-            $fromSha => Revision::fromSha1($fromSha),
-            $toSha => Revision::fromSha1($toSha),
-        ];
-
         $this->parseRevision->expects(self::exactly(2))
             ->method('fromStringForRepository')
-            ->willReturnCallback(static function (string $sha) use ($expectedShas) {
-                self::assertArrayHasKey($sha, $expectedShas);
-
-                return $expectedShas[$sha];
-            });
+            ->willReturnCallback(Revision::fromSha1(...));
 
         $this
             ->locateDependencies
@@ -252,6 +179,7 @@ final class AssertBackwardsCompatibleTest extends TestCase
         $this->compareApi->expects(self::once())->method('__invoke')->willReturn(Changes::empty());
 
         self::assertSame(0, $this->compare->execute($this->input, $this->output));
+        self::assertSame(0, $this->performCheckout->nonRemovedRepositoryCount());
     }
 
     public function testExecuteReturnsNonZeroExitCodeWhenChangesAreDetected(): void
@@ -269,45 +197,9 @@ final class AssertBackwardsCompatibleTest extends TestCase
             ['sources-path', 'src'],
         ]);
 
-        $this->performCheckout->expects(self::exactly(2))
-            ->method('checkout')
-            ->willReturnCallback(function (CheckedOutRepository $repository, Revision $sha) use ($fromSha, $toSha) {
-                $stringRevision = (string) $sha;
-
-                self::assertEquals($repository, $this->sourceRepository);
-                self::assertTrue($stringRevision === $fromSha || $stringRevision === $toSha);
-
-                return $this->sourceRepository;
-            });
-
-        $expectedCalls = new ArrayIterator([
-            $this->sourceRepository,
-            $this->sourceRepository,
-        ]);
-
-        $this->performCheckout->expects(self::exactly(2))
-            ->method('remove')
-            ->willReturnCallback(static function (CheckedOutRepository $repository) use ($expectedCalls): void {
-                self::assertTrue($expectedCalls->valid());
-
-                $expectedRepository = $expectedCalls->current();
-                $expectedCalls->next();
-
-                self::assertSame($expectedRepository, $repository);
-            });
-
-        $expectedShas = [
-            $fromSha => Revision::fromSha1($fromSha),
-            $toSha => Revision::fromSha1($toSha),
-        ];
-
         $this->parseRevision->expects(self::exactly(2))
             ->method('fromStringForRepository')
-            ->willReturnCallback(static function (string $sha) use ($expectedShas) {
-                self::assertArrayHasKey($sha, $expectedShas);
-
-                return $expectedShas[$sha];
-            });
+            ->willReturnCallback(Revision::fromSha1(...));
 
         $this
             ->locateDependencies
@@ -330,6 +222,7 @@ final class AssertBackwardsCompatibleTest extends TestCase
             ));
 
         self::assertSame(3, $this->compare->execute($this->input, $this->output));
+        self::assertSame(0, $this->performCheckout->nonRemovedRepositoryCount());
     }
 
     public function testProvidingMarkdownOptionWritesMarkdownOutput(): void
@@ -347,45 +240,9 @@ final class AssertBackwardsCompatibleTest extends TestCase
             ['sources-path', 'src'],
         ]);
 
-        $this->performCheckout->expects(self::exactly(2))
-            ->method('checkout')
-            ->willReturnCallback(function (CheckedOutRepository $repository, Revision $sha) use ($fromSha, $toSha) {
-                $stringRevision = (string) $sha;
-
-                self::assertEquals($repository, $this->sourceRepository);
-                self::assertTrue($stringRevision === $fromSha || $stringRevision === $toSha);
-
-                return $this->sourceRepository;
-            });
-
-        $expectedCalls = new ArrayIterator([
-            $this->sourceRepository,
-            $this->sourceRepository,
-        ]);
-
-        $this->performCheckout->expects(self::exactly(2))
-            ->method('remove')
-            ->willReturnCallback(static function (CheckedOutRepository $repository) use ($expectedCalls): void {
-                self::assertTrue($expectedCalls->valid());
-
-                $expectedRepository = $expectedCalls->current();
-                $expectedCalls->next();
-
-                self::assertSame($expectedRepository, $repository);
-            });
-
-        $expectedShas = [
-            $fromSha => Revision::fromSha1($fromSha),
-            $toSha => Revision::fromSha1($toSha),
-        ];
-
         $this->parseRevision->expects(self::exactly(2))
             ->method('fromStringForRepository')
-            ->willReturnCallback(static function (string $sha) use ($expectedShas) {
-                self::assertArrayHasKey($sha, $expectedShas);
-
-                return $expectedShas[$sha];
-            });
+            ->willReturnCallback(Revision::fromSha1(...));
 
         $this
             ->locateDependencies
@@ -406,6 +263,7 @@ final class AssertBackwardsCompatibleTest extends TestCase
             });
 
         $this->compare->execute($this->input, $this->output);
+        self::assertSame(0, $this->performCheckout->nonRemovedRepositoryCount());
     }
 
     public function testExecuteWithDefaultRevisionsNotProvidedAndNoDetectedTags(): void
@@ -418,10 +276,6 @@ final class AssertBackwardsCompatibleTest extends TestCase
             ['sources-path', 'src'],
         ]);
 
-        $this
-            ->performCheckout
-            ->expects(self::never())
-            ->method('checkout');
         $this
             ->parseRevision
             ->expects(self::never())
@@ -444,6 +298,7 @@ final class AssertBackwardsCompatibleTest extends TestCase
         $this->expectException(InvariantViolationException::class);
 
         $this->compare->execute($this->input, $this->output);
+        self::assertSame(0, $this->performCheckout->nonRemovedRepositoryCount());
     }
 
     /** @dataProvider validVersionCollections */
@@ -462,44 +317,12 @@ final class AssertBackwardsCompatibleTest extends TestCase
             ['sources-path', 'src'],
         ]);
 
-        $this->performCheckout->expects(self::exactly(2))
-            ->method('checkout')
-            ->willReturnCallback(function (CheckedOutRepository $repository, Revision $sha) use ($fromSha, $toSha) {
-                $stringRevision = (string) $sha;
-
-                self::assertEquals($repository, $this->sourceRepository);
-                self::assertTrue($stringRevision === $fromSha || $stringRevision === $toSha);
-
-                return $this->sourceRepository;
-            });
-
-        $expectedCalls = new ArrayIterator([
-            $this->sourceRepository,
-            $this->sourceRepository,
-        ]);
-
-        $this->performCheckout->expects(self::exactly(2))
-            ->method('remove')
-            ->willReturnCallback(static function (CheckedOutRepository $repository) use ($expectedCalls): void {
-                self::assertTrue($expectedCalls->valid());
-
-                $expectedRepository = $expectedCalls->current();
-                $expectedCalls->next();
-
-                self::assertSame($expectedRepository, $repository);
-            });
-
-        $argumentToRevisionMap = [
-            (string) $pickedVersion => Revision::fromSha1($fromSha),
-            'HEAD' => Revision::fromSha1($toSha),
-        ];
-
         $this->parseRevision->expects(self::exactly(2))
             ->method('fromStringForRepository')
-            ->willReturnCallback(static function (string $argument) use ($argumentToRevisionMap) {
-                self::assertArrayHasKey($argument, $argumentToRevisionMap);
-
-                return $argumentToRevisionMap[$argument];
+            ->willReturnCallback(static fn (string $input): Revision => match ($input) {
+                (string) $pickedVersion => Revision::fromSha1($fromSha),
+                'HEAD' => Revision::fromSha1($toSha),
+                default => throw new LogicException(),
             });
 
         $this->getVersions->expects(self::once())
@@ -528,6 +351,7 @@ final class AssertBackwardsCompatibleTest extends TestCase
         $this->compareApi->expects(self::once())->method('__invoke')->willReturn(Changes::empty());
 
         self::assertSame(0, $this->compare->execute($this->input, $this->output));
+        self::assertSame(0, $this->performCheckout->nonRemovedRepositoryCount());
     }
 
     /** @return VersionCollection[][] */

--- a/test/unit/Command/AssertBackwardsCompatibleTest.php
+++ b/test/unit/Command/AssertBackwardsCompatibleTest.php
@@ -451,7 +451,7 @@ final class AssertBackwardsCompatibleTest extends TestCase
     {
         $fromSha       = Hash\Context::forAlgorithm(Hash\Algorithm::Sha1)->update('fromRevision')->finalize();
         $toSha         = Hash\Context::forAlgorithm(Hash\Algorithm::Sha1)->update('toRevision')->finalize();
-        $pickedVersion = $this->makeVersion('1.0.0');
+        $pickedVersion = self::makeVersion('1.0.0');
 
         $this->input->method('getOption')->willReturnMap([
             ['from', null],
@@ -531,28 +531,28 @@ final class AssertBackwardsCompatibleTest extends TestCase
     }
 
     /** @return VersionCollection[][] */
-    public function validVersionCollections(): array
+    public static function validVersionCollections(): array
     {
         return [
             [
                 new VersionCollection(
-                    $this->makeVersion('1.0.0'),
-                    $this->makeVersion('1.0.1'),
-                    $this->makeVersion('1.0.2'),
+                    self::makeVersion('1.0.0'),
+                    self::makeVersion('1.0.1'),
+                    self::makeVersion('1.0.2'),
                 ),
             ],
             [
                 new VersionCollection(
-                    $this->makeVersion('1.0.0'),
-                    $this->makeVersion('1.0.1'),
+                    self::makeVersion('1.0.0'),
+                    self::makeVersion('1.0.1'),
                 ),
             ],
-            [new VersionCollection($this->makeVersion('1.0.0'))],
+            [new VersionCollection(self::makeVersion('1.0.0'))],
         ];
     }
 
     /** @psalm-param non-empty-string $version */
-    private function makeVersion(string $version): Version
+    private static function makeVersion(string $version): Version
     {
         return Type\instance_of(Version::class)
             ->coerce(Version::fromString($version));

--- a/test/unit/Command/PerformCheckoutOfRevisionForTests.php
+++ b/test/unit/Command/PerformCheckoutOfRevisionForTests.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RoaveTest\BackwardCompatibility\Command;
+
+use Roave\BackwardCompatibility\Git\CheckedOutRepository;
+use Roave\BackwardCompatibility\Git\PerformCheckoutOfRevision;
+use Roave\BackwardCompatibility\Git\Revision;
+use SplObjectStorage;
+
+final class PerformCheckoutOfRevisionForTests implements PerformCheckoutOfRevision
+{
+    /** @var SplObjectStorage<CheckedOutRepository, int> */
+    private SplObjectStorage $checkedOutRepositories;
+
+    public function __construct()
+    {
+        $this->checkedOutRepositories = new SplObjectStorage();
+    }
+
+    public function checkout(CheckedOutRepository $sourceRepository, Revision $revision): CheckedOutRepository
+    {
+        if (! isset($this->checkedOutRepositories[$sourceRepository])) {
+            $this->checkedOutRepositories[$sourceRepository] = 0;
+        }
+
+        $this->checkedOutRepositories[$sourceRepository] += 1;
+
+        return $sourceRepository;
+    }
+
+    public function remove(CheckedOutRepository $checkedOutRepository): void
+    {
+        $this->checkedOutRepositories[$checkedOutRepository] -= 1;
+
+        if ($this->checkedOutRepositories[$checkedOutRepository] !== 0) {
+            return;
+        }
+
+        unset($this->checkedOutRepositories[$checkedOutRepository]);
+    }
+
+    public function nonRemovedRepositoryCount(): int
+    {
+        $sum = 0;
+
+        foreach ($this->checkedOutRepositories as $repository) {
+            $sum += $this->checkedOutRepositories[$repository];
+        }
+
+        return $sum;
+    }
+}

--- a/test/unit/DetectChanges/BCBreak/ClassBased/AncestorRemovedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/AncestorRemovedTest.php
@@ -44,7 +44,7 @@ final class AncestorRemovedTest extends TestCase
      * @return array<string, array<int, ReflectionClass|array<int, string>>>
      * @psalm-return array<string, array{0: ReflectionClass, 1: ReflectionClass, 2: list<string>}>
      */
-    public function classesToBeTested(): array
+    public static function classesToBeTested(): array
     {
         $locator       = (new BetterReflection())->astLocator();
         $fromReflector = new DefaultReflector(new StringSourceLocator(

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameAbstractTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameAbstractTest.php
@@ -44,7 +44,7 @@ final class ClassBecameAbstractTest extends TestCase
      * @return array<string, array<int, ReflectionClass|array<int, string>>>
      * @psalm-return array<string, array{0: ReflectionClass, 1: ReflectionClass, 2: list<string>}>
      */
-    public function classesToBeTested(): array
+    public static function classesToBeTested(): array
     {
         $locator       = (new BetterReflection())->astLocator();
         $fromReflector = new DefaultReflector(new StringSourceLocator(

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameFinalTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameFinalTest.php
@@ -41,7 +41,7 @@ final class ClassBecameFinalTest extends TestCase
      * @return array<string, array<int, ReflectionClass|array<int, string>>>
      * @psalm-return array<string, array{0: ReflectionClass, 1: ReflectionClass, 2: list<string>}>
      */
-    public function classesToBeTested(): array
+    public static function classesToBeTested(): array
     {
         $locator       = (new BetterReflection())->astLocator();
         $fromReflector = new DefaultReflector(new StringSourceLocator(

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameInterfaceTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameInterfaceTest.php
@@ -43,7 +43,7 @@ final class ClassBecameInterfaceTest extends TestCase
      * @return array<string, array<int, ReflectionClass|array<int, string>>>
      * @psalm-return array<string, array{0: ReflectionClass, 1: ReflectionClass, 2: list<string>}>
      */
-    public function classesToBeTested(): array
+    public static function classesToBeTested(): array
     {
         $locator       = (new BetterReflection())->astLocator();
         $fromReflector = new DefaultReflector(new StringSourceLocator(

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameInternalTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameInternalTest.php
@@ -42,7 +42,7 @@ final class ClassBecameInternalTest extends TestCase
      * @return array<string, array<int, ReflectionClass|array<int, string>>>
      * @psalm-return array<string, array{0: ReflectionClass, 1: ReflectionClass, 2: list<string>}>
      */
-    public function classesToBeTested(): array
+    public static function classesToBeTested(): array
     {
         $locator       = (new BetterReflection())->astLocator();
         $fromReflector = new DefaultReflector(new StringSourceLocator(

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameTraitTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ClassBecameTraitTest.php
@@ -44,7 +44,7 @@ final class ClassBecameTraitTest extends TestCase
      * @return array<string, array<int, ReflectionClass|array<int, string>>>
      * @psalm-return array<string, array{0: ReflectionClass, 1: ReflectionClass, 2: list<string>}>
      */
-    public function classesToBeTested(): array
+    public static function classesToBeTested(): array
     {
         $locator       = (new BetterReflection())->astLocator();
         $fromReflector = new DefaultReflector(new StringSourceLocator(

--- a/test/unit/DetectChanges/BCBreak/ClassBased/ConstantRemovedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/ConstantRemovedTest.php
@@ -41,7 +41,7 @@ final class ConstantRemovedTest extends TestCase
      * @return array<string, array<int, ReflectionClass|array<int, string>>>
      * @psalm-return array<string, array{0: ReflectionClass, 1: ReflectionClass, 2: list<string>}>
      */
-    public function classesToBeTested(): array
+    public static function classesToBeTested(): array
     {
         $locator = (new BetterReflection())->astLocator();
 

--- a/test/unit/DetectChanges/BCBreak/ClassBased/EnumCasesChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/EnumCasesChangedTest.php
@@ -69,7 +69,7 @@ final class EnumCasesChangedTest extends TestCase
      * @return array<string, array<int, ReflectionClass|array<int, string>>>
      * @psalm-return array<string, array{0: ReflectionClass, 1: ReflectionClass, 2: list<string>}>
      */
-    public function enumsToBeTested(): array
+    public static function enumsToBeTested(): array
     {
         $locator = (new BetterReflection())->astLocator();
 

--- a/test/unit/DetectChanges/BCBreak/ClassBased/MethodRemovedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/MethodRemovedTest.php
@@ -41,7 +41,7 @@ final class MethodRemovedTest extends TestCase
      * @return array<string, array<int, ReflectionClass|array<int, string>>>
      * @psalm-return array<string, array{0: ReflectionClass, 1: ReflectionClass, 2: list<string>}>
      */
-    public function classesToBeTested(): array
+    public static function classesToBeTested(): array
     {
         $locator = (new BetterReflection())->astLocator();
 

--- a/test/unit/DetectChanges/BCBreak/ClassBased/PropertyRemovedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/PropertyRemovedTest.php
@@ -42,7 +42,7 @@ final class PropertyRemovedTest extends TestCase
      * @return array<string, array<int, ReflectionClass|array<int, string>>>
      * @psalm-return array<string, array{0: ReflectionClass, 1: ReflectionClass, 2: list<string>}>
      */
-    public function classesToBeTested(): array
+    public static function classesToBeTested(): array
     {
         $locator = (new BetterReflection())->astLocator();
 

--- a/test/unit/DetectChanges/BCBreak/ClassConstantBased/ClassConstantValueChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassConstantBased/ClassConstantValueChangedTest.php
@@ -48,7 +48,7 @@ final class ClassConstantValueChangedTest extends TestCase
      *     2: list<string>
      * }>
      */
-    public function constantsToBeTested(): array
+    public static function constantsToBeTested(): array
     {
         $astLocator = (new BetterReflection())->astLocator();
 

--- a/test/unit/DetectChanges/BCBreak/ClassConstantBased/ClassConstantVisibilityReducedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassConstantBased/ClassConstantVisibilityReducedTest.php
@@ -48,7 +48,7 @@ final class ClassConstantVisibilityReducedTest extends TestCase
      *     2: list<string>
      * }>
      */
-    public function constantsToBeTested(): array
+    public static function constantsToBeTested(): array
     {
         $astLocator = (new BetterReflection())->astLocator();
 

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/FunctionBecameInternalTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/FunctionBecameInternalTest.php
@@ -48,7 +48,7 @@ final class FunctionBecameInternalTest extends TestCase
      *     2: list<string>
      * }>
      */
-    public function functionsToBeTested(): array
+    public static function functionsToBeTested(): array
     {
         $astLocator = (new BetterReflection())->astLocator();
 

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterByReferenceChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterByReferenceChangedTest.php
@@ -51,7 +51,7 @@ final class ParameterByReferenceChangedTest extends TestCase
      *     2: list<string>
      * }>
      */
-    public function functionsToBeTested(): array
+    public static function functionsToBeTested(): array
     {
         $astLocator = (new BetterReflection())->astLocator();
 

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterDefaultValueChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterDefaultValueChangedTest.php
@@ -95,7 +95,7 @@ final class ParameterDefaultValueChangedTest extends TestCase
      *     2: list<string>
      * }>
      */
-    public function functionsToBeTested(): array
+    public static function functionsToBeTested(): array
     {
         $astLocator    = (new BetterReflection())->astLocator();
         $sourceStubber = (new BetterReflection())->sourceStubber();

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterNameChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterNameChangedTest.php
@@ -50,7 +50,7 @@ final class ParameterNameChangedTest extends TestCase
      *     2: list<string>
      * }>
      */
-    public function functionsToBeTested(): array
+    public static function functionsToBeTested(): array
     {
         $astLocator = (new BetterReflection())->astLocator();
 
@@ -154,7 +154,7 @@ PHP
         $toClassReflector   = new DefaultReflector($toLocator);
         $fromMethod         = $fromClassReflector->reflectClass('TheClass')->getMethod('theMethod');
         $toMethod           = $toClassReflector->reflectClass('TheClass')->getMethod('theMethod');
-        
+
         assert($fromMethod !== null);
         assert($toMethod !== null);
 

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterTypeChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterTypeChangedTest.php
@@ -51,7 +51,7 @@ final class ParameterTypeChangedTest extends TestCase
      *     2: list<string>
      * }>
      */
-    public function functionsToBeTested(): array
+    public static function functionsToBeTested(): array
     {
         $astLocator = (new BetterReflection())->astLocator();
 

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterTypeContravarianceChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/ParameterTypeContravarianceChangedTest.php
@@ -52,7 +52,7 @@ final class ParameterTypeContravarianceChangedTest extends TestCase
      *     2: list<string>
      * }>
      */
-    public function functionsToBeTested(): array
+    public static function functionsToBeTested(): array
     {
         $astLocator = (new BetterReflection())->astLocator();
 

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/RequiredParameterAmountIncreasedTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/RequiredParameterAmountIncreasedTest.php
@@ -51,7 +51,7 @@ final class RequiredParameterAmountIncreasedTest extends TestCase
      *     2: list<string>
      * }>
      */
-    public function functionsToBeTested(): array
+    public static function functionsToBeTested(): array
     {
         $astLocator = (new BetterReflection())->astLocator();
 

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/ReturnTypeByReferenceChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/ReturnTypeByReferenceChangedTest.php
@@ -51,7 +51,7 @@ final class ReturnTypeByReferenceChangedTest extends TestCase
      *     2: list<string>
      * }>
      */
-    public function functionsToBeTested(): array
+    public static function functionsToBeTested(): array
     {
         $astLocator = (new BetterReflection())->astLocator();
 

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/ReturnTypeChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/ReturnTypeChangedTest.php
@@ -51,7 +51,7 @@ final class ReturnTypeChangedTest extends TestCase
      *     2: list<string>
      * }>
      */
-    public function functionsToBeTested(): array
+    public static function functionsToBeTested(): array
     {
         $astLocator = (new BetterReflection())->astLocator();
 

--- a/test/unit/DetectChanges/BCBreak/FunctionBased/ReturnTypeCovarianceChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/FunctionBased/ReturnTypeCovarianceChangedTest.php
@@ -52,7 +52,7 @@ final class ReturnTypeCovarianceChangedTest extends TestCase
      *     2: list<string>
      * }>
      */
-    public function functionsToBeTested(): array
+    public static function functionsToBeTested(): array
     {
         $astLocator = (new BetterReflection())->astLocator();
 

--- a/test/unit/DetectChanges/BCBreak/InterfaceBased/AncestorRemovedTest.php
+++ b/test/unit/DetectChanges/BCBreak/InterfaceBased/AncestorRemovedTest.php
@@ -44,7 +44,7 @@ final class AncestorRemovedTest extends TestCase
      * @return array<string, array<int, ReflectionClass|array<int, string>>>
      * @psalm-return array<string, array{0: ReflectionClass, 1: ReflectionClass, 2: list<string>}>
      */
-    public function interfacesToBeTested(): array
+    public static function interfacesToBeTested(): array
     {
         $locator       = (new BetterReflection())->astLocator();
         $fromReflector = new DefaultReflector(new StringSourceLocator(

--- a/test/unit/DetectChanges/BCBreak/InterfaceBased/InterfaceBecameClassTest.php
+++ b/test/unit/DetectChanges/BCBreak/InterfaceBased/InterfaceBecameClassTest.php
@@ -43,7 +43,7 @@ final class InterfaceBecameClassTest extends TestCase
      * @return array<string, array<int, ReflectionClass|array<int, string>>>
      * @psalm-return array<string, array{0: ReflectionClass, 1: ReflectionClass, 2: list<string>}>
      */
-    public function classesToBeTested(): array
+    public static function classesToBeTested(): array
     {
         $locator       = (new BetterReflection())->astLocator();
         $fromReflector = new DefaultReflector(new StringSourceLocator(

--- a/test/unit/DetectChanges/BCBreak/InterfaceBased/InterfaceBecameTraitTest.php
+++ b/test/unit/DetectChanges/BCBreak/InterfaceBased/InterfaceBecameTraitTest.php
@@ -43,7 +43,7 @@ final class InterfaceBecameTraitTest extends TestCase
      * @return array<string, array<int, ReflectionClass|array<int, string>>>
      * @psalm-return array<string, array{0: ReflectionClass, 1: ReflectionClass, 2: list<string>}>
      */
-    public function classesToBeTested(): array
+    public static function classesToBeTested(): array
     {
         $locator       = (new BetterReflection())->astLocator();
         $fromReflector = new DefaultReflector(new StringSourceLocator(

--- a/test/unit/DetectChanges/BCBreak/InterfaceBased/MethodAddedTest.php
+++ b/test/unit/DetectChanges/BCBreak/InterfaceBased/MethodAddedTest.php
@@ -43,7 +43,7 @@ final class MethodAddedTest extends TestCase
      * @return array<string, array<int, ReflectionClass|array<int, string>>>
      * @psalm-return array<string, array{0: ReflectionClass, 1: ReflectionClass, 2: list<string>}>
      */
-    public function interfacesToBeTested(): array
+    public static function interfacesToBeTested(): array
     {
         $astLocator = (new BetterReflection())->astLocator();
 

--- a/test/unit/DetectChanges/BCBreak/MethodBased/MethodBecameFinalTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/MethodBecameFinalTest.php
@@ -46,7 +46,7 @@ final class MethodBecameFinalTest extends TestCase
      * @return array<string, array<int, ReflectionMethod|array<int, string>>>
      * @psalm-return array<string, array{0: ReflectionMethod, 1: ReflectionMethod, 2: list<string>}>
      */
-    public function propertiesToBeTested(): array
+    public static function propertiesToBeTested(): array
     {
         $astLocator = (new BetterReflection())->astLocator();
 

--- a/test/unit/DetectChanges/BCBreak/MethodBased/MethodConcretenessChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/MethodConcretenessChangedTest.php
@@ -46,7 +46,7 @@ final class MethodConcretenessChangedTest extends TestCase
      * @return array<string, array<int, ReflectionMethod|array<int, string>>>
      * @psalm-return array<string, array{0: ReflectionMethod, 1: ReflectionMethod, 2: list<string>}>
      */
-    public function propertiesToBeTested(): array
+    public static function propertiesToBeTested(): array
     {
         $astLocator = (new BetterReflection())->astLocator();
 

--- a/test/unit/DetectChanges/BCBreak/MethodBased/MethodParameterAddedTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/MethodParameterAddedTest.php
@@ -94,7 +94,7 @@ final class MethodParameterAddedTest extends TestCase
     }
 
     /** @return array<string, array{0: ReflectionMethod, 1: ReflectionMethod, 2: list<string>}> */
-    public function methodsToBeTested(): array
+    public static function methodsToBeTested(): array
     {
         $astLocator = (new BetterReflection())->astLocator();
 

--- a/test/unit/DetectChanges/BCBreak/MethodBased/MethodScopeChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/MethodScopeChangedTest.php
@@ -43,7 +43,7 @@ final class MethodScopeChangedTest extends TestCase
     }
 
     /** @return array<string, array{0: ReflectionMethod, 1: ReflectionMethod, 2: list<string>}> */
-    public function propertiesToBeTested(): array
+    public static function propertiesToBeTested(): array
     {
         $astLocator = (new BetterReflection())->astLocator();
 

--- a/test/unit/DetectChanges/BCBreak/MethodBased/MethodVisibilityReducedTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/MethodVisibilityReducedTest.php
@@ -46,7 +46,7 @@ final class MethodVisibilityReducedTest extends TestCase
      * @return array<string, array<int, ReflectionMethod|array<int, string>>>
      * @psalm-return array<string, array{0: ReflectionMethod, 1: ReflectionMethod, 2: list<string>}>
      */
-    public function propertiesToBeTested(): array
+    public static function propertiesToBeTested(): array
     {
         $astLocator = (new BetterReflection())->astLocator();
 

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyBecameInternalTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyBecameInternalTest.php
@@ -45,7 +45,7 @@ final class PropertyBecameInternalTest extends TestCase
      * @return array<string, array<int, ReflectionProperty|array<int, string>>>
      * @psalm-return array<string, array{0: ReflectionProperty, 1: ReflectionProperty, 2: list<string>}>
      */
-    public function propertiesToBeTested(): array
+    public static function propertiesToBeTested(): array
     {
         $astLocator = (new BetterReflection())->astLocator();
 

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyDefaultValueChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyDefaultValueChangedTest.php
@@ -45,7 +45,7 @@ final class PropertyDefaultValueChangedTest extends TestCase
      * @return array<string, array<int, ReflectionProperty|array<int, string>>>
      * @psalm-return array<string, array{0: ReflectionProperty, 1: ReflectionProperty, 2: list<string>}>
      */
-    public function propertiesToBeTested(): array
+    public static function propertiesToBeTested(): array
     {
         $astLocator = (new BetterReflection())->astLocator();
 

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyScopeChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyScopeChangedTest.php
@@ -45,7 +45,7 @@ final class PropertyScopeChangedTest extends TestCase
      * @return array<string, array<int, ReflectionProperty|array<int, string>>>
      * @psalm-return array<string, array{0: ReflectionProperty, 1: ReflectionProperty, 2: list<string>}>
      */
-    public function propertiesToBeTested(): array
+    public static function propertiesToBeTested(): array
     {
         $astLocator = (new BetterReflection())->astLocator();
 

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyTypeChangedTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyTypeChangedTest.php
@@ -50,7 +50,7 @@ final class PropertyTypeChangedTest extends TestCase
      * @return array<string, array<int, ReflectionProperty|array<int, string>>>
      * @psalm-return array<string, array{0: ReflectionProperty, 1: ReflectionProperty, 2: list<string>}>
      */
-    public function propertiesToBeTested(): array
+    public static function propertiesToBeTested(): array
     {
         $astLocator = (new BetterReflection())->astLocator();
 

--- a/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyVisibilityReducedTest.php
+++ b/test/unit/DetectChanges/BCBreak/PropertyBased/PropertyVisibilityReducedTest.php
@@ -45,7 +45,7 @@ final class PropertyVisibilityReducedTest extends TestCase
      * @return array<string, array<int, ReflectionProperty|array<int, string>>>
      * @psalm-return array<string, array{0: ReflectionProperty, 1: ReflectionProperty, 2: list<string>}>
      */
-    public function propertiesToBeTested(): array
+    public static function propertiesToBeTested(): array
     {
         $astLocator = (new BetterReflection())->astLocator();
 

--- a/test/unit/DetectChanges/BCBreak/TraitBased/TraitBecameClassTest.php
+++ b/test/unit/DetectChanges/BCBreak/TraitBased/TraitBecameClassTest.php
@@ -44,7 +44,7 @@ final class TraitBecameClassTest extends TestCase
      * @return array<string, array<int, ReflectionClass|array<int, string>>>
      * @psalm-return array<string, array{0: ReflectionClass, 1: ReflectionClass, 2: list<string>}>
      */
-    public function classesToBeTested(): array
+    public static function classesToBeTested(): array
     {
         $locator       = (new BetterReflection())->astLocator();
         $fromReflector = new DefaultReflector(new StringSourceLocator(

--- a/test/unit/DetectChanges/BCBreak/TraitBased/TraitBecameInterfaceTest.php
+++ b/test/unit/DetectChanges/BCBreak/TraitBased/TraitBecameInterfaceTest.php
@@ -44,7 +44,7 @@ final class TraitBecameInterfaceTest extends TestCase
      * @return array<string, array<int, ReflectionClass|array<int, string>>>
      * @psalm-return array<string, array{0: ReflectionClass, 1: ReflectionClass, 2: list<string>}>
      */
-    public function classesToBeTested(): array
+    public static function classesToBeTested(): array
     {
         $locator       = (new BetterReflection())->astLocator();
         $fromReflector = new DefaultReflector(new StringSourceLocator(

--- a/test/unit/DetectChanges/Variance/TypeIsContravariantTest.php
+++ b/test/unit/DetectChanges/Variance/TypeIsContravariantTest.php
@@ -46,7 +46,7 @@ final class TypeIsContravariantTest extends TestCase
      *     2: bool
      * }>
      */
-    public function checkedTypes(): array
+    public static function checkedTypes(): array
     {
         $reflector = new DefaultReflector(new StringSourceLocator(
             <<<'PHP'
@@ -468,7 +468,7 @@ PHP
     }
 
     /** @return list<array{ReflectionIntersectionType|ReflectionUnionType|ReflectionNamedType|null}> */
-    public function existingTypes(): array
+    public static function existingTypes(): array
     {
         $reflector = new DefaultReflector(new StringSourceLocator(
             <<<'PHP'
@@ -547,7 +547,7 @@ PHP
     }
 
     /** @return string[][] */
-    public function existingNullableTypeStrings(): array
+    public static function existingNullableTypeStrings(): array
     {
         return [
             ['int'],

--- a/test/unit/DetectChanges/Variance/TypeIsCovariantTest.php
+++ b/test/unit/DetectChanges/Variance/TypeIsCovariantTest.php
@@ -46,7 +46,7 @@ final class TypeIsCovariantTest extends TestCase
      *     2: bool
      * }>
      */
-    public function checkedTypes(): array
+    public static function checkedTypes(): array
     {
         $reflector = new DefaultReflector(new StringSourceLocator(
             <<<'PHP'
@@ -508,7 +508,7 @@ PHP
     }
 
     /** @return list<array{ReflectionIntersectionType|ReflectionUnionType|ReflectionNamedType|null}> */
-    public function existingTypes(): array
+    public static function existingTypes(): array
     {
         $reflector = new DefaultReflector(new StringSourceLocator(
             <<<'PHP'
@@ -588,7 +588,7 @@ PHP
     }
 
     /** @return string[][] */
-    public function existingNullableTypeStrings(): array
+    public static function existingNullableTypeStrings(): array
     {
         return [
             ['int'],

--- a/test/unit/Formatter/FunctionNameTest.php
+++ b/test/unit/Formatter/FunctionNameTest.php
@@ -30,7 +30,7 @@ final class FunctionNameTest extends TestCase
      *     1: string
      * }>
      */
-    public function functionsToBeTested(): array
+    public static function functionsToBeTested(): array
     {
         $locator = new StringSourceLocator(
             <<<'PHP'
@@ -67,18 +67,18 @@ PHP
                 'N1\b()',
             ],
             'N2\C::d' => [
-                $this->getMethod($reflector->reflectClass('N2\C'), 'd'),
+                self::getMethod($reflector->reflectClass('N2\C'), 'd'),
                 'N2\C::d()',
             ],
             'N2\C#e'  => [
-                $this->getMethod($reflector->reflectClass('N2\C'), 'e'),
+                self::getMethod($reflector->reflectClass('N2\C'), 'e'),
                 'N2\C#e()',
             ],
         ];
     }
 
     /** @param non-empty-string $name */
-    private function getMethod(ReflectionClass $class, string $name): ReflectionMethod
+    private static function getMethod(ReflectionClass $class, string $name): ReflectionMethod
     {
         $method = $class->getMethod($name);
 

--- a/test/unit/Formatter/ReflectionPropertyNameTest.php
+++ b/test/unit/Formatter/ReflectionPropertyNameTest.php
@@ -28,7 +28,7 @@ final class ReflectionPropertyNameTest extends TestCase
      * @return array<string, array<int, string|ReflectionProperty>>
      * @psalm-return array<string, array{0: ReflectionProperty, 1: string}>
      */
-    public function propertiesToBeTested(): array
+    public static function propertiesToBeTested(): array
     {
         $locator = new StringSourceLocator(
             <<<'PHP'

--- a/test/unit/Formatter/SymfonyConsoleTextFormatterTest.php
+++ b/test/unit/Formatter/SymfonyConsoleTextFormatterTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace RoaveTest\BackwardCompatibility\Formatter;
 
-use ArrayIterator;
 use PHPUnit\Framework\TestCase;
 use Psl\SecureRandom;
 use Psl\Str;
@@ -12,7 +11,9 @@ use ReflectionException;
 use Roave\BackwardCompatibility\Change;
 use Roave\BackwardCompatibility\Changes;
 use Roave\BackwardCompatibility\Formatter\SymfonyConsoleTextFormatter;
-use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+use const PHP_EOL;
 
 /** @covers \Roave\BackwardCompatibility\Formatter\SymfonyConsoleTextFormatter */
 final class SymfonyConsoleTextFormatterTest extends TestCase
@@ -23,26 +24,17 @@ final class SymfonyConsoleTextFormatterTest extends TestCase
         $change1Text = SecureRandom\string(8);
         $change2Text = SecureRandom\string(8);
 
-        $output = $this->createMock(OutputInterface::class);
-
-        $expectedMessages = new ArrayIterator([
-            Str\format('[BC] REMOVED: %s', $change1Text),
-            Str\format('     ADDED: %s', $change2Text),
-        ]);
-
-        $output->expects(self::exactly(2))
-            ->method('writeln')
-            ->willReturnCallback(static function (string $text) use ($expectedMessages): void {
-                self::assertTrue($expectedMessages->valid());
-                $expectedText = $expectedMessages->current();
-                $expectedMessages->next();
-
-                self::assertSame($expectedText, $text);
-            });
+        $output = new BufferedOutput();
 
         (new SymfonyConsoleTextFormatter($output))->write(Changes::fromList(
             Change::removed($change1Text, true),
             Change::added($change2Text, false),
         ));
+
+        self::assertSame(
+            Str\format('[BC] REMOVED: %s', $change1Text) . PHP_EOL .
+            Str\format('     ADDED: %s', $change2Text) . PHP_EOL,
+            $output->fetch(),
+        );
     }
 }

--- a/test/unit/Git/GetVersionCollectionFromGitRepositoryTest.php
+++ b/test/unit/Git/GetVersionCollectionFromGitRepositoryTest.php
@@ -28,6 +28,8 @@ final class GetVersionCollectionFromGitRepositoryTest extends TestCase
         Shell\execute('git', ['init'], $tmpGitRepo);
         Shell\execute('git', ['config', 'user.email', 'me@example.com'], $tmpGitRepo);
         Shell\execute('git', ['config', 'user.name', 'Me Again'], $tmpGitRepo);
+        Shell\execute('git', ['config', 'commit.gpgSign', 'false'], $tmpGitRepo);
+        Shell\execute('git', ['config', 'tag.forceSignAnnotated', 'false'], $tmpGitRepo);
         File\write($tmpGitRepo . '/test', SecureRandom\string(8));
         Shell\execute('git', ['add', '.'], $tmpGitRepo);
         Shell\execute('git', ['commit', '-m', '"whatever"'], $tmpGitRepo);

--- a/test/unit/Git/GitCheckoutRevisionToTemporaryPathTest.php
+++ b/test/unit/Git/GitCheckoutRevisionToTemporaryPathTest.php
@@ -63,6 +63,8 @@ final class GitCheckoutRevisionToTemporaryPathTest extends TestCase
         Shell\execute('git', ['init'], $repoPath);
         Shell\execute('git', ['config', 'user.email', 'me@example.com'], $repoPath);
         Shell\execute('git', ['config', 'user.name', 'Mr Magoo'], $repoPath);
+        Shell\execute('git', ['config', 'commit.gpgSign', 'false'], $repoPath);
+        Shell\execute('git', ['config', 'tag.forceSignAnnotated', 'false'], $repoPath);
         Shell\execute('git', ['commit', '-m', 'initial commit', '--allow-empty'], $repoPath);
 
         $firstCommit = Revision::fromSha1(

--- a/test/unit/Git/GitParseRevisionTest.php
+++ b/test/unit/Git/GitParseRevisionTest.php
@@ -12,7 +12,7 @@ use Roave\BackwardCompatibility\Git\GitParseRevision;
 final class GitParseRevisionTest extends TestCase
 {
     /** @return string[][] */
-    public function revisionProvider(): array
+    public static function revisionProvider(): array
     {
         return [
             ['e72a47b', 'e72a47bb9d777c9e73c1322d58a83450d36d9454'],

--- a/test/unit/Git/PickLastVersionFromCollectionTest.php
+++ b/test/unit/Git/PickLastVersionFromCollectionTest.php
@@ -20,7 +20,7 @@ final class PickLastVersionFromCollectionTest extends TestCase
      * @return array<int, array<int, string|array<int, string>>>
      * @psalm-return array<int, array{0: string, 1: list<string>}>
      */
-    public function lastStableVersionForCollectionProvider(): array
+    public static function lastStableVersionForCollectionProvider(): array
     {
         return [
             ['2.2.0', ['1.1.0', '2.1.1', '2.2.0', '1.2.1']],

--- a/test/unit/Git/RevisionTest.php
+++ b/test/unit/Git/RevisionTest.php
@@ -33,7 +33,7 @@ final class RevisionTest extends TestCase
     }
 
     /** @return string[][] */
-    public function invalidRevisionProvider(): array
+    public static function invalidRevisionProvider(): array
     {
         return [
             [''],

--- a/test/unit/SourceLocator/LocatedSourceWithStrippedSourcesDirectoryTest.php
+++ b/test/unit/SourceLocator/LocatedSourceWithStrippedSourcesDirectoryTest.php
@@ -35,9 +35,9 @@ final class LocatedSourceWithStrippedSourcesDirectoryTest extends TestCase
                 ->getFileName(),
         );
     }
-    
+
     /** @return non-empty-list<array{string, string, string}> */
-    public function verifiedPaths(): array
+    public static function verifiedPaths(): array
     {
         return [
             ['/foo/bar.php', '/foo', '/bar.php'],
@@ -46,7 +46,7 @@ final class LocatedSourceWithStrippedSourcesDirectoryTest extends TestCase
             ['/foo/bar.php', '', '/foo/bar.php'],
         ];
     }
-    
+
     public function testWillGetSourcesFromGivenLocatedSource(): void
     {
         self::assertSame(
@@ -81,7 +81,7 @@ final class LocatedSourceWithStrippedSourcesDirectoryTest extends TestCase
         $internalSource
             ->method('isInternal')
             ->willReturn(true);
-        
+
         self::assertFalse(
             (new LocatedSourceWithStrippedSourcesDirectory(
                 $nonInternalSource,
@@ -99,11 +99,11 @@ final class LocatedSourceWithStrippedSourcesDirectoryTest extends TestCase
     public function testWillGetExtensionNameFromGivenLocatedSource(): void
     {
         $extensionSource = $this->createMock(LocatedSource::class);
-        
+
         $extensionSource
             ->method('getExtensionName')
             ->willReturn('the-extension');
-        
+
         self::assertSame(
             'the-extension',
             (new LocatedSourceWithStrippedSourcesDirectory($extensionSource, '/some/source/directory'))
@@ -168,16 +168,16 @@ final class LocatedSourceWithStrippedSourcesDirectoryTest extends TestCase
             'Method is re-declared in the subclass',
         );
     }
-    
+
     /** @return array<string, array{ReflectionMethod}> */
-    public function methodsDeclaredByLocatedSource(): array
+    public static function methodsDeclaredByLocatedSource(): array
     {
         $methods = array_filter(
             (new ReflectionClass(LocatedSourceWithStrippedSourcesDirectory::class))
                 ->getMethods(),
             static fn (ReflectionMethod $method): bool => $method->isPublic() && ! $method->isStatic(),
         );
-        
+
         return array_combine(
             array_map(static fn (ReflectionMethod $method): string => $method->getName(), $methods),
             array_map(static fn (ReflectionMethod $method): array => [$method], $methods),

--- a/test/unit/SourceLocator/ReplaceSourcePathOfLocatedSourcesTest.php
+++ b/test/unit/SourceLocator/ReplaceSourcePathOfLocatedSourcesTest.php
@@ -30,7 +30,7 @@ final class ReplaceSourcePathOfLocatedSourcesTest extends TestCase
         $reflector  = $this->createMock(Reflector::class);
         $source     = $this->createMock(LocatedSource::class);
         $identifier = new Identifier('find-me', new IdentifierType(IdentifierType::IDENTIFIER_CLASS));
-        
+
         $next->expects(self::once())
             ->method('findReflection')
             ->with(
@@ -39,7 +39,7 @@ final class ReplaceSourcePathOfLocatedSourcesTest extends TestCase
                 $identifier,
             )
             ->willReturn($reflection);
-        
+
         self::assertSame(
             $reflection,
             (new ReplaceSourcePathOfLocatedSources($next, '/foo'))
@@ -88,7 +88,7 @@ final class ReplaceSourcePathOfLocatedSourcesTest extends TestCase
     }
 
     /** @return array<string, array{ReflectionMethod}> */
-    public function methodsDeclaredByReplaceSourcePathOfLocatedSources(): array
+    public static function methodsDeclaredByReplaceSourcePathOfLocatedSources(): array
     {
         $methods = array_filter(
             (new ReflectionClass(ReplaceSourcePathOfLocatedSources::class))


### PR DESCRIPTION
Fix #740 

This makes the test suite compatible with the latest PHPUnit version and upgrades everything to it, which removes the SEGFAULTs we were having previously.

(the first commit is from #737, a rebase to sync is more than enough to remove it from the last merged branch)