### PR TITLE
Add modification type in json output

### DIFF
--- a/Resources/errors.schema.json
+++ b/Resources/errors.schema.json
@@ -52,6 +52,9 @@
               "type": "null"
             }
           ]
+        },
+        "modificationType": {
+          "type": "string"
         }
       },
       "required": [

--- a/src/Change.php
+++ b/src/Change.php
@@ -71,6 +71,11 @@ final class Change
         return $this->modificationType === self::SKIPPED;
     }
 
+    public function getModificationType(): string
+    {
+        return $this->modificationType;
+    }
+
     /** @internal */
     public function withFilePositionsIfNotAlreadySet(
         string|null $file,

--- a/src/Formatter/JsonFormatter.php
+++ b/src/Formatter/JsonFormatter.php
@@ -31,6 +31,7 @@ final class JsonFormatter implements OutputFormatter
                 'path' => $change->file === null ? null : Str\replace($change->file, $basePath, ''),
                 'line' => $change->line,
                 'column' => $change->column,
+                'modificationType' => $change->getModificationType(),
             ];
         }
 

--- a/test/unit/Formatter/JsonFormatterTest.php
+++ b/test/unit/Formatter/JsonFormatterTest.php
@@ -63,13 +63,13 @@ final class JsonFormatterTest extends TestCase
 
         $expected = [
             'errors' => [
-                ['description' => 'foo', 'path' => null, 'line' => null, 'column' => null],
-                ['description' => 'bar', 'path' => null, 'line' => null, 'column' => null],
-                ['description' => 'baz', 'path' => 'baz-file.php', 'line' => null, 'column' => null],
-                ['description' => 'tab', 'path' => 'tab-file.php', 'line' => 5, 'column' => null],
-                ['description' => 'taz', 'path' => 'taz-file.php', 'line' => 6, 'column' => 15],
-                ['description' => 'tar', 'path' => 'tar-file.php', 'line' => -1, 'column' => -1],
-                ['description' => 'file-in-checked-out-dir', 'path' => 'subpath/file-in-checked-out-dir.php', 'line' => 10, 'column' => 20],
+                ['description' => 'foo', 'path' => null, 'line' => null, 'column' => null, 'modificationType' => 'removed'],
+                ['description' => 'bar', 'path' => null, 'line' => null, 'column' => null, 'modificationType' => 'added'],
+                ['description' => 'baz', 'path' => 'baz-file.php', 'line' => null, 'column' => null, 'modificationType' => 'changed'],
+                ['description' => 'tab', 'path' => 'tab-file.php', 'line' => 5, 'column' => null, 'modificationType' => 'changed'],
+                ['description' => 'taz', 'path' => 'taz-file.php', 'line' => 6, 'column' => 15, 'modificationType' => 'changed'],
+                ['description' => 'tar', 'path' => 'tar-file.php', 'line' => -1, 'column' => -1, 'modificationType' => 'changed'],
+                ['description' => 'file-in-checked-out-dir', 'path' => 'subpath/file-in-checked-out-dir.php', 'line' => 10, 'column' => 20, 'modificationType' => 'changed'],
             ],
         ];
 
@@ -86,7 +86,7 @@ final class JsonFormatterTest extends TestCase
 
         self::assertJsonStringEqualsJsonString(
             <<<'OUTPUT'
-{"errors":[{"description":"foo","path":null,"line":null,"column":null},{"description":"bar","path":null,"line":null,"column":null},{"description":"baz","path":"baz-file.php","line":null,"column":null},{"description":"tab","path":"tab-file.php","line":5,"column":null},{"description":"taz","path":"taz-file.php","line":6,"column":15},{"description":"tar","path":"tar-file.php","line":-1,"column":-1},{"description":"file-in-checked-out-dir","path":"subpath\/file-in-checked-out-dir.php","line":10,"column":20}]}
+{"errors":[{"description":"foo","path":null,"line":null,"column":null,"modificationType":"removed"},{"description":"bar","path":null,"line":null,"column":null,"modificationType":"added"},{"description":"baz","path":"baz-file.php","line":null,"column":null,"modificationType":"changed"},{"description":"tab","path":"tab-file.php","line":5,"column":null,"modificationType":"changed"},{"description":"taz","path":"taz-file.php","line":6,"column":15,"modificationType":"changed"},{"description":"tar","path":"tar-file.php","line":-1,"column":-1,"modificationType":"changed"},{"description":"file-in-checked-out-dir","path":"subpath\/file-in-checked-out-dir.php","line":10,"column":20,"modificationType":"changed"}]}
 
 OUTPUT
             ,


### PR DESCRIPTION
This is needed to understand if it was a BC break or a issue to parse the file. 

This information is currently exposed in the markdown and other output formatters