### PR TITLE
bug: `protected` method in final class -> `private` is not a BC break

### DIFF
--- a/src/DetectChanges/BCBreak/ClassBased/MethodRemoved.php
+++ b/src/DetectChanges/BCBreak/ClassBased/MethodRemoved.php
@@ -44,9 +44,8 @@ final class MethodRemoved implements ClassBased
     /** @return array<string, ReflectionMethod> */
     private function accessibleMethods(ReflectionClass $class): array
     {
-        $methods = Vec\filter($class->getMethods(), function (ReflectionMethod $method): bool {
-            return ($method->isPublic()
-                || $method->isProtected())
+        $methods = Vec\filter($class->getMethods(), function (ReflectionMethod $method) use ($class): bool {
+            return $this->isAccessibleMethod($method, $class)
                 && ! $this->isInternalDocComment($method->getDocComment());
         });
 
@@ -56,6 +55,15 @@ final class MethodRemoved implements ClassBased
             }),
             $methods,
         );
+    }
+
+    private function isAccessibleMethod(ReflectionMethod $method, ReflectionClass $class): bool
+    {
+        if ($method->isPublic()) {
+            return true;
+        }
+
+        return $method->isProtected() && ! $class->isFinal();
     }
 
     private function isInternalDocComment(string|null $comment): bool

--- a/test/unit/DetectChanges/BCBreak/ClassBased/MethodRemovedTest.php
+++ b/test/unit/DetectChanges/BCBreak/ClassBased/MethodRemovedTest.php
@@ -13,6 +13,7 @@ use Roave\BetterReflection\BetterReflection;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflector\DefaultReflector;
 use Roave\BetterReflection\SourceLocator\Type\SingleFileSourceLocator;
+use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
 
 use function array_map;
 use function iterator_to_array;
@@ -59,6 +60,48 @@ final class MethodRemovedTest extends TestCase
                     '[BC] REMOVED: Method RoaveTestAsset\ClassWithMethodsBeingRemoved#removedPublicMethod() was removed',
                     '[BC] REMOVED: Method RoaveTestAsset\ClassWithMethodsBeingRemoved#removedProtectedMethod() was removed',
                 ],
+            ],
+            'final class with protected changing to private' => [
+                (new DefaultReflector(new StringSourceLocator(
+                    <<<'PHP'
+                    <?php
+                    final class FinalClassWithProtectedMethod {
+                        protected function foo(string $bar): void {}
+                    }
+                    PHP,
+                    $locator,
+                )))->reflectClass('FinalClassWithProtectedMethod'),
+                (new DefaultReflector(new StringSourceLocator(
+                    <<<'PHP'
+                    <?php
+                    final class FinalClassWithProtectedMethod {
+                        private function foo(string $bar): void {}
+                    }
+                    PHP,
+                    $locator,
+                )))->reflectClass('FinalClassWithProtectedMethod'),
+                [],
+            ],
+            'final class with public changing to private' => [
+                (new DefaultReflector(new StringSourceLocator(
+                    <<<'PHP'
+                    <?php
+                    final class FinalClassWithPublicMethod {
+                        public function foo(string $bar): void {}
+                    }
+                    PHP,
+                    $locator,
+                )))->reflectClass('FinalClassWithPublicMethod'),
+                (new DefaultReflector(new StringSourceLocator(
+                    <<<'PHP'
+                    <?php
+                    final class FinalClassWithPublicMethod {
+                        private function foo(string $bar): void {}
+                    }
+                    PHP,
+                    $locator,
+                )))->reflectClass('FinalClassWithPublicMethod'),
+                ['[BC] REMOVED: Method FinalClassWithPublicMethod#foo() was removed'],
             ],
         ];
     }


### PR DESCRIPTION
A method should only be considered "accessible" outside the class if:
 
* It is `public`
* It is `protected` and the class is NOT `final`

Previously, `protected` methods in `final` classes were incorrectly 
considered to be accessible. This meant that changing one to `protected`
would incorrectly be reported as a BC break.

This PR introduces two commits - one that introduces a new testcase to prove the issue, and a second with the fix. I will push separately so that CI shows the new test failing initially.