### PR TITLE
fix: adding optional parameters to contructor

### DIFF
--- a/src/DetectChanges/BCBreak/MethodBased/MethodParameterAdded.php
+++ b/src/DetectChanges/BCBreak/MethodBased/MethodParameterAdded.php
@@ -33,12 +33,7 @@ final class MethodParameterAdded implements MethodBased
         // new optional parameters of constructors are not BC breaks,
         // as the method signature of child classes does not need to match the parent
         if ($fromMethod->isConstructor()) {
-            foreach ($added as $key => $paramName) {
-                $parameter = $toMethod->getParameter($paramName);
-                if ($parameter->isOptional()) {
-                    unset($added[$key]);
-                }
-            }
+            $added = array_filter($added, static fn (string $paramName) => !($toMethod->getParameter($paramName)?->isOptional()));
         }
 
         return Changes::fromList(

--- a/src/DetectChanges/BCBreak/MethodBased/MethodParameterAdded.php
+++ b/src/DetectChanges/BCBreak/MethodBased/MethodParameterAdded.php
@@ -30,7 +30,7 @@ final class MethodParameterAdded implements MethodBased
         if ($fromMethod->isConstructor()) {
             // new optional parameters of constructors are not BC breaks,
             // as the method signature of child classes does not need to match the parent
-            $toParameters = array_filter($toParameters, static fn (ReflectionParameter $param) => !$param->isOptional());
+            $toParameters = array_filter($toParameters, static fn (ReflectionParameter $param) => ! $param->isOptional());
         }
 
         $added = array_diff(

--- a/src/DetectChanges/BCBreak/MethodBased/MethodParameterAdded.php
+++ b/src/DetectChanges/BCBreak/MethodBased/MethodParameterAdded.php
@@ -25,16 +25,17 @@ final class MethodParameterAdded implements MethodBased
             return Changes::empty();
         }
 
+        $toParameters = $toMethod->getParameters();
+        if ($fromMethod->isConstructor()) {
+            // new optional parameters of constructors are not BC breaks,
+            // as the method signature of child classes does not need to match the parent
+            $toParameters = array_filter($toParameters, static fn (ReflectionParameter $param) => !$param->isOptional());
+        }
+
         $added = array_diff(
-            array_map(static fn (ReflectionParameter $param) => $param->getName(), $toMethod->getParameters()),
+            array_map(static fn (ReflectionParameter $param) => $param->getName(), $toParameters),
             array_map(static fn (ReflectionParameter $param) => $param->getName(), $fromMethod->getParameters()),
         );
-
-        // new optional parameters of constructors are not BC breaks,
-        // as the method signature of child classes does not need to match the parent
-        if ($fromMethod->isConstructor()) {
-            $added = array_filter($added, static fn (string $paramName) => !($toMethod->getParameter($paramName)?->isOptional()));
-        }
 
         return Changes::fromList(
             ...array_map(

--- a/src/DetectChanges/BCBreak/MethodBased/MethodParameterAdded.php
+++ b/src/DetectChanges/BCBreak/MethodBased/MethodParameterAdded.php
@@ -11,6 +11,7 @@ use Roave\BetterReflection\Reflection\ReflectionMethod;
 use Roave\BetterReflection\Reflection\ReflectionParameter;
 
 use function array_diff;
+use function array_filter;
 use function array_map;
 
 /**

--- a/src/DetectChanges/BCBreak/MethodBased/MethodParameterAdded.php
+++ b/src/DetectChanges/BCBreak/MethodBased/MethodParameterAdded.php
@@ -30,6 +30,17 @@ final class MethodParameterAdded implements MethodBased
             array_map(static fn (ReflectionParameter $param) => $param->getName(), $fromMethod->getParameters()),
         );
 
+        // new optional parameters of constructors are not BC breaks,
+        // as the method signature of child classes does not need to match the parent
+        if ($fromMethod->isConstructor()) {
+            foreach ($added as $key => $paramName) {
+                $parameter = $toMethod->getParameter($paramName);
+                if ($parameter->isOptional()) {
+                    unset($added[$key]);
+                }
+            }
+        }
+
         return Changes::fromList(
             ...array_map(
                 static fn (string $paramName): Change => Change::added(

--- a/test/unit/DetectChanges/BCBreak/MethodBased/MethodParameterAddedTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/MethodParameterAddedTest.php
@@ -151,7 +151,7 @@ PHP
             'privateMethod' => [],
             'removedParameter' => [],
             'twoParams' => [],
-            '__construct' => ['[BC] ADDED: Parameter two was added to Method __construct() of class TheClass',],
+            '__construct' => ['[BC] ADDED: Parameter two was added to Method __construct() of class TheClass'],
         ];
 
         return array_combine(

--- a/test/unit/DetectChanges/BCBreak/MethodBased/MethodParameterAddedTest.php
+++ b/test/unit/DetectChanges/BCBreak/MethodBased/MethodParameterAddedTest.php
@@ -109,6 +109,7 @@ class TheClass {
     public function twoParams(int $one, int $two) {}
     private function privateMethod() {}
     public function removedParameter(int $one, array $options = []) {}
+    public function __construct(int $one) {}
 }
 PHP
             ,
@@ -127,6 +128,7 @@ class TheClass {
     public function twoParams(int $one, int $two) {}
     private function privateMethod(array $options = []) {}
     public function removedParameter(int $one) {}
+    public function __construct(int $one, int $two, array $options = []) {}
 }
 PHP
             ,
@@ -149,6 +151,7 @@ PHP
             'privateMethod' => [],
             'removedParameter' => [],
             'twoParams' => [],
+            '__construct' => ['[BC] ADDED: Parameter two was added to Method __construct() of class TheClass',],
         ];
 
         return array_combine(


### PR DESCRIPTION
Adding optional parameters to a constructor is not a breaking change, since child classes do not need to match the signature of the parent. Only non-optional parameters (or parameters with default values before the last required parameter) are a breaking change in a constructor, as here the method call would need to be adjusted

### Small example

```php
class A {
    public function __construct(int $one, int $two = 666) {}
}

class B extends A {
    public function __construct(string $whatever) {
        parent::__construct(1);
    }
}

new B('foo');
new A(2);
```

Adding the parameter `$two` in class `A` here does not have an effect on neither constructing `A` nor `B`.

You can try it out here: https://3v4l.org/QYsC8

fixes https://github.com/Roave/BackwardCompatibilityCheck/issues/978